### PR TITLE
lookup the site-packages directory that get-pip (pip) creates

### DIFF
--- a/recipe_pipenv.Dockerfile
+++ b/recipe_pipenv.Dockerfile
@@ -10,16 +10,16 @@ ONBUILD RUN apk add --no-cache wget; \
             apk del --no-cache wget
 
 ONBUILD RUN echo '#!/usr/bin/env python' > /tmp/pipenv/get-pipenv; \
-            echo "import os, sys, subprocess as sp, tempfile, glob" >> /tmp/pipenv/get-pipenv; \
+            echo "import os, sys, subprocess as sp, tempfile, glob, sysconfig" >> /tmp/pipenv/get-pipenv; \
             echo "try:" >> /tmp/pipenv/get-pipenv; \
             echo "  x=tempfile.TemporaryDirectory()" >> /tmp/pipenv/get-pipenv; \
             echo "  temp=x.name" >> /tmp/pipenv/get-pipenv; \
             echo "except:" >> /tmp/pipenv/get-pipenv; \
             echo "  temp=tempfile.mkdtemp()" >> /tmp/pipenv/get-pipenv; \
             echo "sp.Popen([sys.executable, os.path.dirname(os.path.realpath(__file__))+'/get-pip.py', '--no-cache-dir', '-I', '--root', temp, 'virtualenv']).wait()" >> /tmp/pipenv/get-pipenv; \
-            echo "os.environ['PYTHONPATH'] = glob.glob(temp+'/usr/local/lib/python*/*-packages')[0]" >> /tmp/pipenv/get-pipenv; \
+            echo "os.environ['PYTHONPATH'] = glob.glob(os.path.join(temp, sysconfig.get_path('purelib').lstrip(os.path.sep)))[0]" >> /tmp/pipenv/get-pipenv; \
             echo "d='${PIPENV_VIRTUALENV}'" >> /tmp/pipenv/get-pipenv; \
-            echo "sp.Popen([sys.executable, temp+'/usr/local/bin/virtualenv', '${PIPENV_VIRTUALENV}']).wait()" >> /tmp/pipenv/get-pipenv; \
+            echo "sp.Popen([sys.executable, os.path.join(temp, os.path.dirname(os.path.dirname(os.path.dirname(sysconfig.get_path('purelib').lstrip(os.path.sep)))), 'bin/virtualenv'), '${PIPENV_VIRTUALENV}']).wait()" >> /tmp/pipenv/get-pipenv; \
             echo "os.environ.pop('PYTHONPATH')" >> /tmp/pipenv/get-pipenv; \
             echo "sp.Popen(['${PIPENV_VIRTUALENV}/bin/pip', 'install', '--no-cache-dir', 'pipenv==${PIPENV_VERSION}']).wait()" >> /tmp/pipenv/get-pipenv; \
             echo "os.symlink('${PIPENV_VIRTUALENV}/bin/pipenv', '/usr/local/bin/pipenv')" >> /tmp/pipenv/get-pipenv; \
@@ -28,4 +28,3 @@ ONBUILD RUN echo '#!/usr/bin/env python' > /tmp/pipenv/get-pipenv; \
             echo "except:" >> /tmp/pipenv/get-pipenv; \
             echo "  import shutil" >> /tmp/pipenv/get-pipenv; \
             echo "  shutil.rmtree(temp)" >> /tmp/pipenv/get-pipenv
-


### PR DESCRIPTION
get-pip.py installs itself into a site-packages directory at different locations depending on the linux distro. use the same mechanism that pip uses to figure out this location.