### PR TITLE
Updated tini recipe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ A docker recipe is a (usually very small) docker image that is included in a mul
 
    RUN echo stuff
 
-   COPY --from=tini /usr/local/bin/tini /usr/local/bin/tini
-   COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
+   COPY --from=tini /usr/local /usr/local
+   COPY --from=gosu /usr/local /usr/local
 
 How to use
 ==========
@@ -68,7 +68,7 @@ tini
 ============ ====
 Name         tini
 Build Args   ``TINI_VERSION`` - Version of tini to download
-Output files ``/usr/local/bin/tini``
+Output files ``/usr/local/bin/tini`` and ``/usr/local/bin/_tini``
 ============ ====
 
 Tini is a process reaper, and should be used in dockers that spawn new processes
@@ -82,7 +82,7 @@ There is a similar version for alpine: tini-musl
    FROM vsiri/recipe:tini as tini
    FROM debian:9
    RUN apt-get update; apt-get install vim
-   COPY --from=tini /usr/local/bin/tini /usr/local/bin/tini
+   COPY --from=tini COPY /usr/local /usr/local
 
 gosu
 ----
@@ -188,7 +188,7 @@ Docker is a tool for running container applications
    FROM vsiri/recipe:docker as docker
    FROM debian:9
    RUN apt-get update; apt-get install vim
-   COPY --from=docker /usr/local/bin /usr/local/bin
+   COPY --from=docker /usr/local /usr/local
 
 Docker compose
 --------------

--- a/recipe_tini-musl.Dockerfile
+++ b/recipe_tini-musl.Dockerfile
@@ -2,11 +2,13 @@ FROM alpine:3.8
 
 SHELL ["sh", "-euxvc"]
 
+ADD tini /usr/local/bin/tini
+
 ONBUILD ARG TINI_VERSION=v0.16.1
 ONBUILD RUN apk add --no-cache --virtual .deps gnupg curl ca-certificates; \
             # download tini
-            curl -fsLo /usr/local/bin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-muslc-amd64; \
-            chmod +x /usr/local/bin/tini; \
+            curl -fsLo /usr/local/bin/_tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-muslc-amd64; \
+            chmod +x /usr/local/bin/tini /usr/local/bin/_tini; \
             # verify the signature
             curl -fsLo /dev/shm/tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-muslc-amd64.asc; \
             export GNUPGHOME=/dev/shm; \
@@ -17,6 +19,6 @@ ONBUILD RUN apk add --no-cache --virtual .deps gnupg curl ca-certificates; \
                                     pgp.mit.edu) ; do \
                 gpg --batch --keyserver "$server" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
             done; \
-            gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/tini; \
+            gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/_tini; \
             # cleanup to keep intermediate image samell
             apk del .deps

--- a/recipe_tini.Dockerfile
+++ b/recipe_tini.Dockerfile
@@ -2,11 +2,13 @@ FROM alpine:3.8
 
 SHELL ["sh", "-euxvc"]
 
+ADD tini /usr/local/bin/tini
+
 ONBUILD ARG TINI_VERSION=v0.18.0
 ONBUILD RUN apk add --no-cache --virtual .deps gnupg curl ca-certificates; \
             # download tini
-            curl -fsLo /usr/local/bin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini; \
-            chmod +x /usr/local/bin/tini; \
+            curl -fsLo /usr/local/bin/_tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini; \
+            chmod +x /usr/local/bin/_tini /usr/local/bin/tini; \
             # verify the signature
             curl -fsLo /dev/shm/tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc; \
             export GNUPGHOME=/dev/shm; \
@@ -17,6 +19,6 @@ ONBUILD RUN apk add --no-cache --virtual .deps gnupg curl ca-certificates; \
                                     pgp.mit.edu) ; do \
                 gpg --batch --keyserver "$server" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
             done; \
-            gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/tini; \
+            gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/_tini; \
             # cleanup to keep intermediate image samell
             apk del .deps

--- a/tini
+++ b/tini
@@ -6,7 +6,7 @@ set -eu
 # and report the issue
 
 # If running in singularity
-if [ -n "${SINGULARITY_NAME+set}" ]; then
+if [ -d "/.singularity.d" ]; then
   while (( $# )); do
     case "${1}" in
       # Signifies the rest is the command, so break

--- a/tini
+++ b/tini
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+
+set -eu
+
+# If this script ever gives you a problem, just change your entrypoint to _tini
+# and report the issue
+
+# If running in singularity
+if [ -n "${SINGULARITY_NAME+set}" ]; then
+  while (( $# )); do
+    case "${1}" in
+      # Signifies the rest is the command, so break
+      --)
+        shift 1
+        break
+        ;;
+      # Args that take one arg
+      -e|-p)
+        shift 2
+        ;;
+      # No extra args (-e/-p are merged into one arg)
+      -l|--version|-v|-vv|-vvv|-s|-w|-g|-e*|-p*)
+        shift 1
+        ;;
+      *) # No match must mean the real command
+        break
+        ;;
+    esac
+  done
+  exec ${@+"${@}"}
+else
+  if [ -e /usr/local/bin/_tini ]; then
+    exec /usr/local/bin/_tini ${@+"${@}"}
+  else
+    exec "$(dirname "$0")/_tini" ${@+"${@}"}
+  fi
+fi


### PR DESCRIPTION
When we run singularity, we need to not use tini. It reaps zombies, and running tini with it spews warnings and just isn't needed. So I came up with this wrapper

@scott-vsi  thoughts?