### PR TITLE
make tini EOL windows friendly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 get-pipenv eol=lf
+tini eol=lf


### PR DESCRIPTION
new "tini" file pulls with wrong EOL on windows - add correct EOL to .gitattributes.