### PR TITLE
ci_load for test images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,7 @@ jobs:
             COMPOSE_FILE=./tests/docker-compose.yml
             IFS=$'\n'
             SERVICES=( $(docker-compose -f $COMPOSE_FILE ps --services) )
-            for service in "${SERVICES[@]}"
-            do
+            for service in "${SERVICES[@]}"; do
               python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
                 --cache-repo "vsiri/ci_cache_recipes" $COMPOSE_FILE $service
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,19 @@ jobs:
       - image: vsiri/circleci:bash-compose-lfs
     environment:
       VSI_COMMON_DIR: /vsi
+    shell: /bin/bash -eo pipefail
     working_directory: ~/repo
 
     steps:
+
+      - run:
+          name: Install software
+          command: |
+            apk update
+            apk add python3
+            python3 --version
+            pip3 install pyyaml
+
       - checkout
       - run:
           name: Checkout vsi_common
@@ -17,7 +27,21 @@ jobs:
       - setup_remote_docker
 
       - run:
-          name: Build recipes
+          name: Build recipes with unit tests (ci_load)
+          command: |
+            docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
+            COMPOSE_FILE=./tests/docker-compose.yml
+            IFS=$'\n'
+            SERVICES=( $(docker-compose -f $COMPOSE_FILE ps --services) )
+            for service in "${SERVICES[@]}"
+            do
+              python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
+                --cache-repo "vsiri/ci_cache_recipes" $COMPOSE_FILE $service
+            done
+
+
+      - run:
+          name: Build remaining recipes
           command: |
             sed -i 's|context: ../..|context: ${VSI_COMMON_DIR}|' docker-compose.yml
             docker-compose build

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2.2'
+
+services:
+
+  test_pipenv:
+    build:
+      context: .
+      dockerfile: test_pipenv.Dockerfile
+      args:
+        PIPENV_VERSION: "2018.5.18"
+        PIPENV_VIRTUALENV: "/foo"
+        PIPENV_PYTHON: "/bar"
+    image: vsiri/test_recipe:test_pipenv

--- a/tests/test-pipenv.bsh
+++ b/tests/test-pipenv.bsh
@@ -5,39 +5,15 @@ if [ -z ${VSI_COMMON_DIR+set} ]; then
 fi
 
 . "${VSI_COMMON_DIR}/tests/testlib.bsh"
-. "${VSI_COMMON_DIR}/linux/uwecho.bsh"
 : ${DOCKER=docker}
-
-setup()
-{
-  temp_image="$(mktemp -u test_XXXXXXXXXXXXXXXX | tr '[:upper:]' '[:lower:]')"
-}
 
 command -v "${DOCKER}" &> /dev/null || skip_next_test
 begin_test "Pipenv"
 (
   setup_test
 
-  uwecho 'FROM vsiri/recipe:pipenv AS pipenv
-
-          FROM python:3
-          SHELL ["/usr/bin/env", "bash", "-euxvc"]
-
-          COPY --from=pipenv /usr/local /usr/local
-          RUN ln -s "$(which python3)" /bar; \
-              for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done' > Dockerfile
-
-  docker build -t ${temp_image} --build-arg=PIPENV_VERSION=2018.5.18 \
-                                --build-arg=PIPENV_VIRTUALENV=/foo \
-                                --build-arg=PIPENV_PYTHON=/bar \
-                                .
-
-  [ "$(docker run --rm ${temp_image} bash -c 'head -n1 /foo/bin/pipenv; readlink /foo/bin/python; /foo/bin/pipenv --version')" = $'#!/foo/bin/python\n/bar\npipenv, version 2018.05.18' ]
+  RESULT=$(docker run --rm vsiri/test_recipe:test_pipenv bash -c 'head -n1 /foo/bin/pipenv; readlink /foo/bin/python; /foo/bin/pipenv --version')
+  [ "$RESULT" = $'#!/foo/bin/python\n/bar\npipenv, version 2018.05.18' ]
 
 )
 end_test
-
-teardown()
-{
-  docker rmi ${temp_image} > /dev/null || :
-}

--- a/tests/test_pipenv.Dockerfile
+++ b/tests/test_pipenv.Dockerfile
@@ -1,0 +1,8 @@
+FROM vsiri/recipe:pipenv AS pipenv
+
+FROM python:3
+SHELL ["/usr/bin/env", "bash", "-euxvc"]
+
+COPY --from=pipenv /usr/local /usr/local
+RUN ln -s "$(which python3)" /bar; \
+    for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done


### PR DESCRIPTION
reconfigure tests to make use of ci_load from vsi_common
- explicit test dockerfiles & docker-compose.yml
- test images are linked to the vsiri/ci_cache_recipes dockerhub repo
- new services should be automatically linked to dockerhub

This is expected to reduce CI time for larger recipes with unit tests.