### PR TITLE
Conda python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ VSI Common
 
 ============ ==========
 Name         VSI Common
-Output files ``/vsi/*``
+Output dir   ``/vsi``
 ============ ==========
 
 Some VSI Common functions are needed in the container, this provides a mechanism to copy them in, even if the :file:`just` executable is used.
@@ -71,7 +71,7 @@ tini
 ============ ====
 Name         tini
 Build Args   ``TINI_VERSION`` - Version of tini to download
-Output files ``/usr/local/bin/tini`` and ``/usr/local/bin/_tini``
+Output dir   ``/usr/local``
 ============ ====
 
 Tini is a process reaper, and should be used in dockers that spawn new processes
@@ -93,7 +93,7 @@ gosu
 ============ ====
 Name         gosu
 Build Args   ``GOSU_VERSION`` - Version of gosu to download
-Output files ``/usr/local/bin/gosu``
+Output dir   ``/usr/local``
 ============ ====
 
 sudo written with docker automation in mind (no passwords ever)
@@ -118,7 +118,7 @@ ep - envplate
 ============ ==
 Name         ep
 Build Args   ``EP_VERSION`` - Version of ep to download
-Output files ``/usr/local/bin/ep``
+Output dir   ``/usr/local``
 ============ ==
 
 ep is a simple way to apply bourne shell style variable name substitution to any generic configuration file for applications that do not support environment variable name substitution
@@ -138,7 +138,7 @@ jq - JSON Processor
 ============ ==
 Name         jq
 Build Args   ``JQ_VERSION`` - Version of jq to download
-Output files ``/usr/local/bin/jq``
+Output dir   ``/usr/local``
 ============ ==
 
 jq is a lightweight and flexible command-line JSON processor
@@ -158,7 +158,7 @@ ninja
 ============ =====
 Name         ninja
 Build Args   ``NINJA_VERSION`` - Version of Ninja to download
-Output files ``/usr/local/bin/ninja``
+Output dir   ``/usr/local``
 ============ =====
 
 Ninja is generally a better/faster alternative to GNU Make.
@@ -179,7 +179,7 @@ Docker
 =========== ==============
 Name        Docker
 Build Args  ``DOCKER_VERSION`` - Version of docker to download
-Output dirs ``/usr/local/bin/`` including ``docker`` and several other files.
+Output dir  ``/usr/local`` including ``docker`` and several other files.
 =========== ==============
 
 Docker is a tool for running container applications
@@ -238,7 +238,7 @@ git Large File Support
 =========== =======
 Name        git lfs
 Build Args  ``GIT_LFS_VERSION`` - Version of git-lfs to download
-Output dirs ``/usr/local/bin/git-lfs``
+Output dir  ``/usr/local/bin/git-lfs``
 =========== =======
 
 git-lfs gives git the ability to handle large files gracefully.
@@ -261,7 +261,7 @@ CMake
 ============ =====
 Name         CMake
 Build Args   ``CMAKE_VERSION`` - Version of CMake to download
-Output files ``/cmake/*``
+Output dir   ``/usr/local``
 ============ =====
 
 CMake is a cross-platform family of tools designed to build, test and package software
@@ -273,7 +273,7 @@ CMake is a cross-platform family of tools designed to build, test and package so
    FROM vsiri/recipe:cmake as cmake
    FROM debian:9
    RUN apt-get update; apt-get install vim  # This line is just an example
-   COPY --from=cmake /cmake /usr/local
+   COPY --from=cmake /usr/local /usr/local
 
 Pipenv
 ------
@@ -283,7 +283,7 @@ Name        Pipenv
 Build Args  ``PIPENV_VERSION`` - Version of pipenv source to download
 Build Args  ``PIPENV_VIRTUALENV`` - The location of the pipenv virtualenv
 Build Args  ``PIPENV_PYTHON`` - Optional default python executable to use
-Output dirs ``/tmp/pipenv/*``
+Output dir  ``/usr/local``
 =========== ======
 
 Pipenv is the new way to manage python requirements (within a virtualenv) on project.
@@ -330,7 +330,7 @@ One True Awk
 ============ ============
 Name         One True Awk
 Build Args   ``ONETRUEAWK_VERSION`` - Version of one true awk to download
-Output files ``/usr/local/bin/awk``
+Output dir   ``/usr/local``
 ============ ============
 
 https://github.com/onetrueawk/awk is a severly limited version awk that some primative operating systems use. This recipe will help in testing against that version.
@@ -350,7 +350,7 @@ GDAL
 ============ ============
 Name         GDAL
 Build Args   ``GDAL_VERSION`` - Version of GDAL to download
-Output files ``/gdal/usr/local/*``
+Output dir   ``/gdal/usr/local``
 ============ ============
 
 Compiles GDAL v3, including PROJ v6, ECW J2K 5.5, OPENJPEG 2.3
@@ -393,6 +393,25 @@ Compiles GDAL v3, including PROJ v6, ECW J2K 5.5, OPENJPEG 2.3
 
    CMD ["gdalinfo", "--version"]
 
+Conda's python
+--------------
+
+============ ============
+Name         Python
+Build Args   ``PYTHON_VERSION`` - Version of python to download
+Output files ``/usr/local/bin/awk``
+============ ============
+
+https://github.com/onetrueawk/awk is a severly limited version awk that some primative operating systems use. This recipe will help in testing against that version.
+
+.. rubric:: Example
+
+.. code-block:: Dockerfile
+
+   FROM vsiri/recipe:onetrueawk as onetrueawk
+   FROM debian:9
+   RUN apt-get update; apt-get install vim  # This line is just an example
+   COPY --from=onetrueawk /usr/local /usr/local
 
 
 J.U.S.T.

--- a/README.rst
+++ b/README.rst
@@ -399,19 +399,21 @@ Conda's python
 ============ ============
 Name         Python
 Build Args   ``PYTHON_VERSION`` - Version of python to download
-Output files ``/usr/local/bin/awk``
+Output dir   ``/usr/local``
 ============ ============
 
-https://github.com/onetrueawk/awk is a severly limited version awk that some primative operating systems use. This recipe will help in testing against that version.
+This is not a recipe for installing anaconda or miniconda, rather it internally uses miniconda to install a "not" conda python. This python will still bare the markings of Anaconda, but does not have all the conda modifications, and works as a normal and extremely portable version of python for glibc linux.
+
+This is the easiest way to install an arbitrary version of python on an arbitrary linux distro.
 
 .. rubric:: Example
 
 .. code-block:: Dockerfile
 
-   FROM vsiri/recipe:onetrueawk as onetrueawk
-   FROM debian:9
+   FROM vsiri/recipe:conda-python as python
+   FROM ubuntu:16.04
    RUN apt-get update; apt-get install vim  # This line is just an example
-   COPY --from=onetrueawk /usr/local /usr/local
+   COPY --from=python /usr/local /usr/local
 
 
 J.U.S.T.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,3 +106,11 @@ services:
       # args:
       #   GDAL_VERSION: "${GDAL_VERSION}"
     image: vsiri/recipe:gdal
+
+  conda-python:
+    build:
+      context: .
+      dockerfile: recipe_conda_python.Dockerfile
+      # args:
+      #   PYTHON_VERSION: "${PYTHON_VERSION}"
+    image: vsiri/recipe:conda-python

--- a/recipe_amanda_deb.Dockerfile
+++ b/recipe_amanda_deb.Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:8
 
-SHELL ["bash", "-xveuc"]
+SHELL ["/usr/bin/env", "bash", "-xveuc"]
 
 ONBUILD ARG AMANDA_VERSION=tags/community_3_4_5
 ONBUILD RUN set -euxv; \

--- a/recipe_cmake.Dockerfile
+++ b/recipe_cmake.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-SHELL ["sh", "-euxvc"]
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ONBUILD ARG CMAKE_VERSION=3.16.3
 ONBUILD RUN apk add --no-cache --virtual .deps unzip curl ca-certificates; \
@@ -8,7 +8,7 @@ ONBUILD RUN apk add --no-cache --virtual .deps unzip curl ca-certificates; \
             curl -fsSLo cmake.txt https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-SHA-256.txt; \
             grep 'Linux-x86_64\.tar\.gz' cmake.txt | sha256sum -c - > /dev/null; \
             tar xf /cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz; \
-            mv /cmake-${CMAKE_VERSION}-Linux-x86_64 /cmake; \
-            touch -r cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz /cmake; \
+            mv /cmake-${CMAKE_VERSION}-Linux-x86_64/* /usr/local/; \
+            rmdir /cmake-${CMAKE_VERSION}-Linux-x86_64; \
             rm /cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz; \
             apk del .deps

--- a/recipe_conda_python.Dockerfile
+++ b/recipe_conda_python.Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:buster-slim
+
+SHELL ["/usr/bin/env", "bash", "-euxvc"]
+
+RUN apt-get update -y; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y  --no-install-recommends \
+        ca-certificates curl ; \
+    rm -rf /var/lib/apt/lists/* ;
+
+RUN curl -fsSLO https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh; \
+    sh /Miniconda3-latest-Linux-x86_64.sh -b -p /conda -s; \
+    rm /Miniconda3-latest-Linux-x86_64.sh
+
+ONBUILD ARG PYTHON_VERSION=3.8.5
+ONBUILD RUN /conda/bin/conda create -y -p "/usr/local/" "python==${PYTHON_VERSION}"

--- a/recipe_docker.Dockerfile
+++ b/recipe_docker.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-SHELL ["sh", "-euxvc"]
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ONBUILD ARG DOCKER_VERSION=19.03.5
 

--- a/recipe_ep.Dockerfile
+++ b/recipe_ep.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-SHELL ["sh", "-euxvc"]
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ONBUILD ARG EP_VERSION=1.0.0-RC1
 #No signature :(

--- a/recipe_gdal.Dockerfile
+++ b/recipe_gdal.Dockerfile
@@ -83,7 +83,7 @@ RUN TEMP_DIR=/tmp/openjpeg ; \
     #
     # download & unzip
     TAR_FILE=v${OPENJPEG_VERSION}.tar.gz ; \
-    curl -fLO https://github.com/uclouvain/openjpeg/archive/${TAR_FILE} ; \
+    curl -fsSLO https://github.com/uclouvain/openjpeg/archive/${TAR_FILE} ; \
     tar -xvf ${TAR_FILE} --strip-components=1 ; \
     #
     # configure, build, & install
@@ -127,7 +127,7 @@ RUN TEMP_DIR=/tmp/ecw ; \
     fi ; \
     #
     # download & unzip
-    curl -fLO "https://go.hexagongeospatial.com/${ZIP_FILE}" ; \
+    curl -fsSLO "https://go.hexagongeospatial.com/${ZIP_FILE}" ; \
     unzip ${ZIP_FILE} ; \
     #
     # unpack & cleanup
@@ -177,7 +177,7 @@ RUN TEMP_DIR=/tmp/proj ; \
     #
     # download & unzip
     TAR_FILE=${PROJ_VERSION}.tar.gz ; \
-    curl -fLO https://github.com/OSGeo/PROJ/archive/${TAR_FILE} ; \
+    curl -fsSLO https://github.com/OSGeo/PROJ/archive/${TAR_FILE} ; \
     tar -xvf ${TAR_FILE} --strip-components=1 ; \
     #
     # configure, build, & install
@@ -258,7 +258,7 @@ RUN TEMP_DIR=/tmp/gdal ; \
     #
     # download & unzip
     TAR_FILE=gdal-${GDAL_VERSION}.tar.gz ; \
-    curl -fLO http://download.osgeo.org/gdal/${GDAL_VERSION}/${TAR_FILE} ; \
+    curl -fsSLO http://download.osgeo.org/gdal/${GDAL_VERSION}/${TAR_FILE} ; \
     tar -xvf ${TAR_FILE} --strip-components=1 ; \
     #
     # configure, build, & install

--- a/recipe_gosu.Dockerfile
+++ b/recipe_gosu.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-SHELL ["sh", "-euxvc"]
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ONBUILD ARG GOSU_VERSION=1.11
 ONBUILD RUN apk add --no-cache --virtual .deps curl dpkg gnupg openssl; \

--- a/recipe_jq.Dockerfile
+++ b/recipe_jq.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-SHELL ["sh", "-euxvc"]
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ONBUILD ARG JQ_VERSION=1.6
 #No signature :(

--- a/recipe_ninja.Dockerfile
+++ b/recipe_ninja.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-SHELL ["sh", "-euxvc"]
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ONBUILD ARG NINJA_VERSION=v1.10.0
 #No signature :(

--- a/recipe_pipenv.Dockerfile
+++ b/recipe_pipenv.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-SHELL ["sh", "-euxvc"]
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ONBUILD ARG PIPENV_VERSION=2018.11.26
 ONBUILD ARG PIPENV_VIRTUALENV=/usr/local/pipenv

--- a/recipe_tini-musl.Dockerfile
+++ b/recipe_tini-musl.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-SHELL ["sh", "-euxvc"]
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ADD tini /usr/local/bin/tini
 

--- a/recipe_tini.Dockerfile
+++ b/recipe_tini.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-SHELL ["sh", "-euxvc"]
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ADD tini /usr/local/bin/tini
 

--- a/recipe_vsi.Dockerfile
+++ b/recipe_vsi.Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.11
 
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
+
 COPY . /vsi
 
 # Unfortunately pyinstaller changed everything to 700


### PR DESCRIPTION
I refactors a bunch of recipes to be more uniform. Most of those changes have no affect.

- Breaking change: I noticed the cmake recipe did not output files to `/usr/local` like every other recipe was supposed to, so I fixed that.
- @drewgilliam I didn't want to mess with the gdal recipe, but it looks like it too outputs to `/gdal/usr/local` instead of just `/usr/local`. This should be rectified in the future.