### PR TITLE
circleci & test 30_get-pipenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,30 @@
 version: 2.1
 
 # -----
+# CircleCI orbs
+# -----
+orbs:
+  win: circleci/windows@2.4.0
+
+# -----
 # CircleCI custom commands
 # -----
 commands:
+
+  # checkout docker_recipes within vsi_common:
+  # -- checkout vsi_common master, then navigate to docker_recipes submodule
+  #    and checkout current docker_recipes SHA
+  # -- requires $VSI_COMMON to be defined
+  # -- allows use of "just" targets as needed (such as "just test recipe")
+  checkout_in_vsi_common:
+    description: Checkout code in vsi_common
+    steps:
+      - run:
+          name: Checkout code in vsi_common
+          command: |
+            git clone --recursive https://github.com/VisionSystemsInc/vsi_common.git "${VSI_COMMON_DIR}"
+            cd "${VSI_COMMON_DIR}/docker/recipes"
+            git checkout "${CIRCLE_SHA1}"
 
   # run "ci_load" command on user-selected docker-compose file
   # - cache is updated only from master branch of main repo (not forks)
@@ -65,13 +86,15 @@ commands:
 # -----
 jobs:
 
+  # linux docker environment
   build_and_test:
     docker:
       - image: vsiri/circleci:bash-compose-lfs
-    environment:
-      VSI_COMMON_DIR: /vsi
     shell: /bin/bash -eo pipefail
-    working_directory: ~/repo
+    working_directory: ~/vsi
+    environment:
+      VSI_COMMON_DIR: /root/vsi
+      RECIPE_DIR: /root/vsi/docker/recipes
 
     steps:
 
@@ -83,34 +106,74 @@ jobs:
             python3 --version
             pip3 install pyyaml
 
-      - checkout
-      - run:
-          name: Checkout vsi_common
-          command: |
-            git clone --recursive https://github.com/VisionSystemsInc/vsi_common.git /vsi
-
+      - checkout_in_vsi_common
       - setup_remote_docker
 
       - run:
           name: Additional setup
           command: |
-            sed -i 's|context: ../..|context: ${VSI_COMMON_DIR}|' docker-compose.yml
             docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
 
       - ci_load:
           step_name: Build recipes (ci_load)
-          compose_file: ./docker-compose.yml
+          compose_file: ${RECIPE_DIR}/docker-compose.yml
 
       - ci_load:
           step_name: Build tests (ci_load)
-          compose_file: ./tests/docker-compose.yml
+          compose_file: ${RECIPE_DIR}/tests/docker-compose.yml
 
       - run:
           name: Run integration tests
-          environment:
-            TESTLIB_DISCOVERY_DIR: /root/repo/tests
           command: |
-            "${VSI_COMMON_DIR}/tests/run_tests"
+            source setup.env
+            just test recipe
+
+
+  # test selected scripts for windows compatability
+  windows_test:
+    executor:
+      name: win/default
+      shell: bash.exe
+    working_directory: "C:/Users/circleci/vsi"
+    environment:
+      VSI_COMMON_DIR: "C:/Users/circleci/vsi"
+      RECIPE_DIR: "C:/Users/circleci/vsi/docker/recipes"
+
+    steps:
+      - run: systeminfo
+      # - run: printenv
+
+      - run:
+          name: Update bash environment
+          command: |
+
+            # Give preference to bash utilities via PATH.
+            # For example, prefer "C:/Program Files/Git/usr/bin/find" over
+            # the windows executable "C:/Windows/system32/find"
+            echo 'export PATH="/c/Program Files/Git/usr/bin":${PATH}' >> "${BASH_ENV}"
+
+            # setting an alias for find did not work command did not seem to work
+            # echo 'alias find="/c/Program Files/Git/usr/bin/find.exe"' >> "${BASH_ENV}"
+
+      - checkout_in_vsi_common
+
+      - run:
+          name: Run integration tests
+          command: |
+
+            # activate "just" from vsi_common
+            # cd "${VSI_COMMON_DIR}"
+            source setup.env
+
+            # helper function to run a single test
+            # $1 = test file id (e.g., "pipenv" for test-pipenv.bsh)
+            # $2 = test description (e.g., "30_get-pipenv" in test-pipenv.bsh)
+            run_single_test() {
+              TESTLIB_RUN_SINGLE_TEST="$2" just test recipe "$1"
+            }
+
+            # run selected tests
+            run_single_test pipenv 30_get-pipenv
 
 # -----
 # CircleCI workflows
@@ -119,3 +182,4 @@ workflows:
   recipes:
     jobs:
       - build_and_test
+      # - windows_test

--- a/tests/test-pipenv.bsh
+++ b/tests/test-pipenv.bsh
@@ -8,6 +8,7 @@ source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 
 : ${DOCKER=docker}
 
+# test pipenv version in docker
 command -v "${DOCKER}" &> /dev/null || skip_next_test
 begin_test "Pipenv"
 (
@@ -16,5 +17,41 @@ begin_test "Pipenv"
   RESULT=$(docker run --rm vsiri/test_recipe:test_pipenv bash -c 'head -n1 /foo/bin/pipenv; readlink /foo/bin/python; /foo/bin/pipenv --version')
   [ "$RESULT" = $'#!/foo/bin/python\n/bar\npipenv, version 2018.05.18' ]
 
+)
+end_test
+
+# test 30_get-pipenv script without a container
+# Note this test assumes a system-wide python is available
+begin_test "30_get-pipenv"
+(
+  setup_test
+
+  # environment
+  export PIPENV_VERSION="2020.8.13"
+  export LC_ALL=C.UTF-8
+  export LANG=C.UTF-8
+
+  # output directory
+  OUTPUT_DIR="$(mktemp -d)"
+
+  # install virtualenv with pipenv to TEMP_DIR
+  source "${VSI_COMMON_DIR}/docker/recipes/30_get-pipenv"
+  install_pipenv "${OUTPUT_DIR}"
+
+  # expected pipenv executable
+  if [ "${OS-}" = "Windows_NT" ]; then
+    PIPENV="${OUTPUT_DIR}/Scripts/pipenv.exe"
+  else
+    PIPENV="${OUTPUT_DIR}/bin/pipenv"
+  fi
+
+  # pipenv result
+  RESULT="$("${PIPENV}" --version | sed 's|\r||g')"
+
+  # cleanup
+  rm -rf "${OUTPUT_DIR}"
+
+  # test
+  [ "$RESULT" = 'pipenv, version 2020.8.13' ]
 )
 end_test


### PR DESCRIPTION
Refactor circleci
- Checkout docker_recipes as vsi_common submodule (first checkout vsi_common, then checkout docker_recipes `CIRCLE_SHA1` as submodule)
- Add windows environment (currently disabled) for selected windows testing, such as testing 30_get-pipenv outside a container for windows setup.

Test 30_get-pipenv outside a docker environment, allowing users to utilize the script for general install of an isolated pipenv setup. 