### PR TITLE
test with python:3.8

### DIFF
--- a/tests/test_gdal.Dockerfile
+++ b/tests/test_gdal.Dockerfile
@@ -1,6 +1,6 @@
 FROM vsiri/recipe:gdal as gdal
 
-FROM python:3
+FROM python:3.8
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
 COPY --from=gdal /usr/local /usr/local

--- a/tests/test_pipenv.Dockerfile
+++ b/tests/test_pipenv.Dockerfile
@@ -1,6 +1,6 @@
 FROM vsiri/recipe:pipenv AS pipenv
 
-FROM python:3
+FROM python:3.8
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
 COPY --from=pipenv /usr/local /usr/local


### PR DESCRIPTION
pin tests previously based on dockerhub `python:3` to `python3.8`.  dockerhub `python:3` is now python v3.9.0 and not everything is compatible (e.g., virtualenv zipapp is not available for python 3.9).