### PR TITLE
30_get-pipenv versioned virtualenv zipapp

### DIFF
--- a/30_get-pipenv
+++ b/30_get-pipenv
@@ -167,10 +167,13 @@ fi
 #
 # Install pipenv into a virtualenv. Does not need to have pip already installed and does not use privileged permissions. Makes use of the virtualenv zipapp, as per https://virtualenv.pypa.io/en/latest/installation.html#via-zipapp
 #
+# While virtualenv documentation recommends download of the virtualenv zipapp file from https://bootstrap.pypa.io/virtualenv, this script instead downloads from https://github.com/pypa/get-virtualenv/ which offered versioned zipapp files.  This avoids possible breaking changes introduced at the pypa bootstrap site.
+#
 # :Arguments: [``$1``] - The location of the virtualenv, defaults to ``${PIPENV_VIRTUALENV-${HOME}/pipenv}``
 # :Parameters: * ``PIPENV_PYTHON`` - Optionally specify which python you want to use. Default is to favor python3, trying ``python3``, ``python``, then finally falling back to ``python2``.
 #              * ``PIPENV_VERSION`` - The version of pipenv to install, defaults - ``2018.11.26``
 #              * ``VIRTUALENV_PYZ`` - Name of downloaded ``virtualenv.pyz``, else it will attempt to download it itself.
+#              * ``VIRTUALENV_PYZ_VERSION`` - The version of ``virtualenv.pyz`` to download, defaults to ``20.0.31``
 #**
 install_pipenv()
 {
@@ -182,6 +185,7 @@ install_pipenv()
   local output_dir="${1-${PIPENV_VIRTUALENV-${HOME}/pipenv}}"
   local pipenv_ver="${PIPENV_VERSION:-2018.11.26}"
   local virtualenv_pyz=${VIRTUALENV_PYZ-}
+  local virtualenv_pyz_version=${VIRTUALENV_PYZ_VERSION:-20.0.31}
 
   # use existing virtualenv
   virtualenv_ver="$("${PIPENV_PYTHON}" -m virtualenv --version 2>/dev/null || :)"
@@ -201,12 +205,12 @@ install_pipenv()
     if [ ! -r "${virtualenv_pyz}" ]; then
 
       # source url
-      local url="$("${PIPENV_PYTHON}" -c "if True:
-          import sys
-          ver = sys.version_info
-          print('https://bootstrap.pypa.io/virtualenv/{}.{}/virtualenv.pyz'
-                .format(ver[0],ver[1]) )
-          ")"
+      # download versioned virtualenv-pyz from github
+      # https://github.com/pypa/virtualenv/issues/1930#issuecomment-683390781
+      #
+      # Download top-level zipapp, as python verioned zipapps are symlinked to the top-level file (for now)
+      # https://github.com/pypa/get-virtualenv/issues/1#issuecomment-580811273
+      local url="https://github.com/pypa/get-virtualenv/raw/${virtualenv_pyz_version}/public/virtualenv.pyz"
       echo "Download virtualenv zipapp from <${url}>" >&2
 
       # download to file


### PR DESCRIPTION
Use versioned virtualenv zipapp in 30_get-pipenv.

While virtualenv documentation recommends download of the virtualenv zipapp file from https://bootstrap.pypa.io/virtualenv, this change instead downloads from https://github.com/pypa/get-virtualenv/ which offered versioned zipapp files.  This avoids possible breaking changes introduced at the pypa bootstrap site, which only hosts the most recent zipapp version.

Fixes windows install issue introduced by virtualenv version 20.0.34
https://app.circleci.com/pipelines/github/VisionSystemsInc/docker_recipes/168/workflows/64bc1367-67be-4f97-badf-0b4a7ec35d20/jobs/282
```
Using virtualenv zipapp
    Download virtualenv zipapp from <https://bootstrap.pypa.io/virtualenv/3.7/virtualenv.pyz>
    Traceback (most recent call last):
      File "C:\tools\miniconda3\lib\runpy.py", line 193, in _run_module_as_main
        "__main__", mod_spec)
      File "C:\tools\miniconda3\lib\runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\__main__.py", line 168, in <module>
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\__main__.py", line 164, in run
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\virtualenv\__main__.py", line 16, in run
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\virtualenv\run\__init__.py", line 28, in cli_run
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\virtualenv\run\session.py", line 46, in run
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\virtualenv\run\session.py", line 53, in _create
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\virtualenv\create\creator.py", line 161, in run
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\virtualenv\create\via_global_ref\builtin\via_global_self_do.py", line 97, in create
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\virtualenv\create\via_global_ref\builtin\ref.py", line 157, in run
      File "C:\Users\circleci\AppData\Local\Temp\test-pipenv.bsh-1034.7KcZGwd7\test1\tmp.MZ0GR35n9U\virtualenv.pyz\virtualenv\util\path\_sync.py", line 53, in copy
      File "C:\tools\miniconda3\lib\shutil.py", line 245, in copy
        copyfile(src, dst, follow_symlinks=follow_symlinks)
      File "C:\tools\miniconda3\lib\shutil.py", line 120, in copyfile
        with open(src, 'rb') as fsrc:
    FileNotFoundError: [Errno 2] No such file or directory: 'C:\\tools\\miniconda3\\Lib\\venv\\scripts\\nt\\python.exe'

```