### PR TITLE
30_get-pipenv consistent VIRTUALENV_VERSION

### DIFF
--- a/30_get-pipenv
+++ b/30_get-pipenv
@@ -173,7 +173,7 @@ fi
 # :Parameters: * ``PIPENV_PYTHON`` - Optionally specify which python you want to use. Default is to favor python3, trying ``python3``, ``python``, then finally falling back to ``python2``.
 #              * ``PIPENV_VERSION`` - The version of pipenv to install, defaults - ``2018.11.26``
 #              * ``VIRTUALENV_PYZ`` - Name of downloaded ``virtualenv.pyz``, else it will attempt to download it itself.
-#              * ``VIRTUALENV_PYZ_VERSION`` - The version of ``virtualenv.pyz`` to download, defaults to ``20.0.31``
+#              * ``VIRTUALENV_VERSION`` - The version of virtualenv to use, affecting both the virtualenv zipapp version and the virtualenv version used by pipenv environment.  defaults to ``20.0.33``
 #**
 install_pipenv()
 {
@@ -185,7 +185,7 @@ install_pipenv()
   local output_dir="${1-${PIPENV_VIRTUALENV-${HOME}/pipenv}}"
   local pipenv_ver="${PIPENV_VERSION:-2018.11.26}"
   local virtualenv_pyz=${VIRTUALENV_PYZ-}
-  local virtualenv_pyz_version=${VIRTUALENV_PYZ_VERSION:-20.0.31}
+  local virtualenv_version=${VIRTUALENV_VERSION:-20.0.33}
 
   # use existing virtualenv
   virtualenv_ver="$("${PIPENV_PYTHON}" -m virtualenv --version 2>/dev/null || :)"
@@ -205,12 +205,12 @@ install_pipenv()
     if [ ! -r "${virtualenv_pyz}" ]; then
 
       # source url
-      # download versioned virtualenv-pyz from github
+      # download versioned virtualenv.pyz from github
       # https://github.com/pypa/virtualenv/issues/1930#issuecomment-683390781
       #
       # Download top-level zipapp, as python verioned zipapps are symlinked to the top-level file (for now)
       # https://github.com/pypa/get-virtualenv/issues/1#issuecomment-580811273
-      local url="https://github.com/pypa/get-virtualenv/raw/${virtualenv_pyz_version}/public/virtualenv.pyz"
+      local url="https://github.com/pypa/get-virtualenv/raw/${virtualenv_version}/public/virtualenv.pyz"
       echo "Download virtualenv zipapp from <${url}>" >&2
 
       # download to file
@@ -235,7 +235,9 @@ install_pipenv()
   else
     output_pip="${output_dir}/bin/pip"
   fi
-  "${output_pip}" install --no-cache-dir pipenv=="${pipenv_ver}"
+  "${output_pip}" install --no-cache-dir \
+      virtualenv=="${virtualenv_version}" \
+      pipenv=="${pipenv_ver}"
 }
 
 #**

--- a/recipe_pipenv.Dockerfile
+++ b/recipe_pipenv.Dockerfile
@@ -5,6 +5,7 @@ SHELL ["/usr/bin/env", "sh", "-euxvc"]
 ONBUILD ARG PIPENV_VERSION=2018.11.26
 ONBUILD ARG PIPENV_VIRTUALENV=/usr/local/pipenv
 ONBUILD ARG PIPENV_PYTHON
+ONBUILD ARG VIRTUALENV_VERSION=20.0.33
 ADD 30_get-pipenv /usr/local/share/just/container_build_patch/30_get-pipenv
 # Save the arg values in the script, for use later when get-pipenv is called
 ONBUILD RUN sed -i -e "3a: \${PIPENV_PYTHON:=${PIPENV_PYTHON-}}" \


### PR DESCRIPTION
Use `$VIRTUALENV_VERSION` to define both the virtualenv zipapp version and the virtualenv version installed in the pipenv environment.

Additionally introduce `VIRTUALENV_VERSION` as an argument to recipe_pipenv. 

Default `$VIRTUALENV_VERSION` to 20.0.33.