### PR TITLE
update recipe_gdal base image after Centos6 end of life

### DIFF
--- a/recipe_gdal.Dockerfile
+++ b/recipe_gdal.Dockerfile
@@ -64,7 +64,7 @@
 # -----------------------------------------------------------------------------
 
 # base image
-FROM quay.io/pypa/manylinux2010_x86_64:2020-07-18-8228e74 as base_image
+FROM quay.io/pypa/manylinux2010_x86_64:2020-12-15-ba3529a as base_image
 
 # Set shell to bash
 SHELL ["/usr/bin/env", "/bin/bash", "-euxvc"]


### PR DESCRIPTION
`recipe_gdal.Dockerfile` is based on the manylinux2010 image, which in turn is based on Centos6
https://github.com/pypa/manylinux/blob/master/docker/Dockerfile-x86_64

As Centos6 has reached end of life
https://wiki.centos.org/About/Product
yum repos were moved
https://grepitout.com/yumrepo-error-all-mirror-urls-are-not-using-ftp-https-or-file/

Update `recipe_gdal.Dockerfile` base image to the latest manylinux2010 image which already handles this problem.  
https://quay.io/repository/pypa/manylinux2010_x86_64?tag=latest&tab=tags

Note we continue to pin the base image to a particular tag (rather than "latest") to reduce docker cache misses of the manylinux2010 image.  Otherwise CI would take a long time, as recipe_gdal would be built from scratch on every change.
