### PR TITLE
fixed base images

### DIFF
--- a/recipe_amanda_deb.Dockerfile
+++ b/recipe_amanda_deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8
+FROM debian:jessie-20210311
 
 SHELL ["/usr/bin/env", "bash", "-xveuc"]
 

--- a/recipe_cmake.Dockerfile
+++ b/recipe_cmake.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_conda_python.Dockerfile
+++ b/recipe_conda_python.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:buster-20210311-slim
 
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
 

--- a/recipe_docker-compose.Dockerfile
+++ b/recipe_docker-compose.Dockerfile
@@ -2,7 +2,7 @@
 # FROM docker/compose:alpine-${DOCKER_COMPOSE_VERSION} as docker-compose_musl
 # FROM docker/compose:debian-${DOCKER_COMPOSE_VERSION} as docker-compose_glib
 
-FROM alpine:3.11
+FROM alpine:3.11.8
 ADD docker-compose /usr/local/bin/docker-compose
 RUN chmod 755 /usr/local/bin/docker-compose
 

--- a/recipe_docker.Dockerfile
+++ b/recipe_docker.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_ep.Dockerfile
+++ b/recipe_ep.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_gdal.Dockerfile
+++ b/recipe_gdal.Dockerfile
@@ -64,7 +64,10 @@
 # -----------------------------------------------------------------------------
 
 # base image
-FROM quay.io/pypa/manylinux2010_x86_64:2020-12-15-ba3529a as base_image
+# Note: until further notice, do not advance past 2021-01-24-4117e7c
+# manylinux removed sqlite3 header files resulting in a build failure.
+# https://github.com/pypa/manylinux/pull/972/files#diff-9c383720bcb0d73540daa84edfb6357f31620ff274e48183c95936cc834252c2R35-R36
+FROM quay.io/pypa/manylinux2010_x86_64:2021-01-24-4117e7c as base_image
 
 # Set shell to bash
 SHELL ["/usr/bin/env", "/bin/bash", "-euxvc"]
@@ -180,7 +183,7 @@ RUN TEMP_DIR=/tmp/proj ; \
     # download & unzip
     TAR_FILE=${PROJ_VERSION}.tar.gz ; \
     curl -fsSLO https://github.com/OSGeo/PROJ/archive/${TAR_FILE} ; \
-    tar -xvf ${TAR_FILE} --strip-components=1 ; \
+    tar -xf ${TAR_FILE} --strip-components=1 ; \
     #
     # configure, build, & install
     ./autogen.sh ; \
@@ -261,7 +264,7 @@ RUN TEMP_DIR=/tmp/gdal ; \
     # download & unzip
     TAR_FILE=gdal-${GDAL_VERSION}.tar.gz ; \
     curl -fsSLO http://download.osgeo.org/gdal/${GDAL_VERSION}/${TAR_FILE} ; \
-    tar -xvf ${TAR_FILE} --strip-components=1 ; \
+    tar -xf ${TAR_FILE} --strip-components=1 ; \
     #
     # configure, build, & install
     # https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/configure

--- a/recipe_gdal.Dockerfile
+++ b/recipe_gdal.Dockerfile
@@ -64,10 +64,7 @@
 # -----------------------------------------------------------------------------
 
 # base image
-# Note: until further notice, do not advance past 2021-01-24-4117e7c
-# manylinux removed sqlite3 header files resulting in a build failure.
-# https://github.com/pypa/manylinux/pull/972/files#diff-9c383720bcb0d73540daa84edfb6357f31620ff274e48183c95936cc834252c2R35-R36
-FROM quay.io/pypa/manylinux2010_x86_64:2021-01-24-4117e7c as base_image
+FROM quay.io/pypa/manylinux2010_x86_64:2021-04-05-b4fd19d as base_image
 
 # Set shell to bash
 SHELL ["/usr/bin/env", "/bin/bash", "-euxvc"]

--- a/recipe_git-lfs.Dockerfile
+++ b/recipe_git-lfs.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_gosu.Dockerfile
+++ b/recipe_gosu.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_jq.Dockerfile
+++ b/recipe_jq.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_ninja.Dockerfile
+++ b/recipe_ninja.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_onetrueawk.Dockerfile
+++ b/recipe_onetrueawk.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_pipenv.Dockerfile
+++ b/recipe_pipenv.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_tini-musl.Dockerfile
+++ b/recipe_tini-musl.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_tini.Dockerfile
+++ b/recipe_tini.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 

--- a/recipe_vsi.Dockerfile
+++ b/recipe_vsi.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 


### PR DESCRIPTION
Non-specific dockerhub tags (e.g., `debian:8`) are typically moving targets, updated/rebuilt far more often than specific tags (e.g., `debian:jessie-20210311`).  This can lead to possible recipe build failures and downstream recipe cache misses.  Update base image tags to more specific/fixed tags to provide more stable recipe builds.

Note `recipe_gdal` required some special care, as a recent change to the manylinux2010 image breaks building against the installed sqlite3 package (manylinux2010 deleted sqlite3 headers; working on a PR to fix the situation).