### PR TITLE
Issue 35

### DIFF
--- a/30_get-pipenv
+++ b/30_get-pipenv
@@ -169,7 +169,9 @@ fi
 #
 # While virtualenv documentation recommends download of the virtualenv zipapp file from https://bootstrap.pypa.io/virtualenv, this script instead downloads from https://github.com/pypa/get-virtualenv/ which offered versioned zipapp files.  This avoids possible breaking changes introduced at the pypa bootstrap site.
 #
-# Prefer use of ``RECIPE_*``` environment variables (e.g., prefer ``RECIPE_PIPENV_VERSION`` over ``PIPENV_VERSION``). Pipenv uses ``PIPENV_{FLAG_NAME}`` to control command line execution via environment variables, as per https://github.com/pypa/pipenv/blob/master/CHANGELOG.rst#features--improvements-4. Use of ``PIPENV_VERSION`` to control the installed pipenv version may cause subsequent calls to pipenv to fail with the error ``Error: Invalid value for '--version': 2020.11.15 is not a valid boolean``.
+# Prefer use of ``RECIPE_*`` environment variables (e.g., prefer ``RECIPE_PIPENV_VERSION`` over ``PIPENV_VERSION``). Pipenv uses ``PIPENV_{FLAG_NAME}`` to control command line execution via environment variables, as per https://github.com/pypa/pipenv/blob/master/CHANGELOG.rst#features--improvements-4. Use of ``PIPENV_VERSION`` to control the installed pipenv version may cause subsequent calls to pipenv to fail with the error ``Error: Invalid value for '--version': 2020.11.15 is not a valid boolean``.
+#
+# Environment variables not starting with ``RECIPE_*`` may be deprecated in the future.
 #
 # :Arguments: [``$1``] - The location of the virtualenv, defaults to ``${RECIPE_PIPENV_VIRTUALENV-${PIPENV_VIRTUALENV-${HOME}/pipenv}}``
 # :Parameters: * ``RECIPE_PIPENV_PYTHON`` or ``PIPENV_PYTHON`` - Optionally specify which python you want to use. Default is to favor python3, trying ``python3``, ``python``, then finally falling back to ``python2``.

--- a/30_get-pipenv
+++ b/30_get-pipenv
@@ -254,9 +254,10 @@ install_pipenv()
 #**
 setup_container_pipenv()
 {
-  ln -s "${1-${PIPENV_VIRTUALENV-${HOME}/pipenv}}/bin/pipenv" "${2-/usr/local/bin/pipenv}"
+  local virtualenv_dir="${1-${RECIPE_PIPENV_VIRTUALENV-${PIPENV_VIRTUALENV-${HOME}/pipenv}}}"
+  ln -s "${virtualenv_dir}/bin/pipenv" "${2-/usr/local/bin/pipenv}"
 
-  cat - > "${1-${PIPENV_VIRTUALENV-${HOME}/pipenv}}/bin/fake_package" << "EOF"
+  cat - > "${virtualenv_dir}/bin/fake_package" << "EOF"
 #!/usr/bin/env sh
 
 set -eu
@@ -273,7 +274,7 @@ if [ ! -e "setup.py" ]; then
   echo "setup(name='${1}', packages=['${2-${1}}'], description='Project')" >> setup.py
 fi
 EOF
-  chmod 755 "${1-${PIPENV_VIRTUALENV-${HOME}/pipenv}}/bin/fake_package"
+  chmod 755 "${virtualenv_dir}/bin/fake_package"
 }
 
 if [ -n "${BASH_SOURCE+set}" ]; then

--- a/30_get-pipenv
+++ b/30_get-pipenv
@@ -182,7 +182,12 @@ install_pipenv()
 {
   # python executable
   local python_exe="${RECIPE_PIPENV_PYTHON:-${PIPENV_PYTHON:-"$( (command -v python3 || command -v python || command -v python2) | head -n 1)"}}"
-  [ -n "${python_exe}" ] # Make sure python was found
+
+  # Make sure python was found
+  if [ -n "${python_exe}" ]; then
+    echo "install_pipenv cannot find python executable. Try setting RECIPE_PIPENV_PYTHON to point to python" >&2
+    return 1
+  fi
 
   # setup
   local output_dir="${1-${RECIPE_PIPENV_VIRTUALENV-${PIPENV_VIRTUALENV-${HOME}/pipenv}}}"

--- a/30_get-pipenv
+++ b/30_get-pipenv
@@ -169,29 +169,32 @@ fi
 #
 # While virtualenv documentation recommends download of the virtualenv zipapp file from https://bootstrap.pypa.io/virtualenv, this script instead downloads from https://github.com/pypa/get-virtualenv/ which offered versioned zipapp files.  This avoids possible breaking changes introduced at the pypa bootstrap site.
 #
-# :Arguments: [``$1``] - The location of the virtualenv, defaults to ``${PIPENV_VIRTUALENV-${HOME}/pipenv}``
-# :Parameters: * ``PIPENV_PYTHON`` - Optionally specify which python you want to use. Default is to favor python3, trying ``python3``, ``python``, then finally falling back to ``python2``.
-#              * ``PIPENV_VERSION`` - The version of pipenv to install, defaults - ``2018.11.26``
-#              * ``VIRTUALENV_PYZ`` - Name of downloaded ``virtualenv.pyz``, else it will attempt to download it itself.
-#              * ``VIRTUALENV_VERSION`` - The version of virtualenv to use, affecting both the virtualenv zipapp version and the virtualenv version used by pipenv environment.  defaults to ``20.0.33``
+# Prefer use of ``RECIPE_*``` environment variables (e.g., prefer ``RECIPE_PIPENV_VERSION`` over ``PIPENV_VERSION``). Pipenv uses ``PIPENV_{FLAG_NAME}`` to control command line execution via environment variables, as per https://github.com/pypa/pipenv/blob/master/CHANGELOG.rst#features--improvements-4. Use of ``PIPENV_VERSION`` to control the installed pipenv version may cause subsequent calls to pipenv to fail with the error ``Error: Invalid value for '--version': 2020.11.15 is not a valid boolean``.
+#
+# :Arguments: [``$1``] - The location of the virtualenv, defaults to ``${RECIPE_PIPENV_VIRTUALENV-${PIPENV_VIRTUALENV-${HOME}/pipenv}}``
+# :Parameters: * ``RECIPE_PIPENV_PYTHON`` or ``PIPENV_PYTHON`` - Optionally specify which python you want to use. Default is to favor python3, trying ``python3``, ``python``, then finally falling back to ``python2``.
+#              * ``RECIPE_PIPENV_VERSION`` or ``PIPENV_VERSION`` - The version of pipenv to install, defaults - ``2020.11.15``
+#              * ``RECIPE_VIRTUALENV_PYZ`` or ``VIRTUALENV_PYZ`` - Name of downloaded ``virtualenv.pyz``, else it will attempt to download it itself.
+#              * ``RECIPE_VIRTUALENV_VERSION`` or ``VIRTUALENV_VERSION`` - The version of virtualenv to use, affecting both the virtualenv zipapp version and the virtualenv version used by pipenv environment.  defaults to ``20.4.5``
+#
 #**
 install_pipenv()
 {
   # python executable
-  : ${PIPENV_PYTHON:="$( (command -v python3 || command -v python || command -v python2) | head -n 1)"}
-  [ -n "${PIPENV_PYTHON}" ] # Make sure python was found
+  local python_exe="${RECIPE_PIPENV_PYTHON:-${PIPENV_PYTHON:-"$( (command -v python3 || command -v python || command -v python2) | head -n 1)"}}"
+  [ -n "${python_exe}" ] # Make sure python was found
 
   # setup
-  local output_dir="${1-${PIPENV_VIRTUALENV-${HOME}/pipenv}}"
-  local pipenv_ver="${PIPENV_VERSION:-2018.11.26}"
-  local virtualenv_pyz=${VIRTUALENV_PYZ-}
-  local virtualenv_version=${VIRTUALENV_VERSION:-20.0.33}
+  local output_dir="${1-${RECIPE_PIPENV_VIRTUALENV-${PIPENV_VIRTUALENV-${HOME}/pipenv}}}"
+  local pipenv_ver="${RECIPE_PIPENV_VERSION:-${PIPENV_VERSION:-2020.11.15}}"
+  local virtualenv_pyz="${RECIPE_VIRTUALENV_PYZ:-${VIRTUALENV_PYZ:-}}"
+  local virtualenv_version="${RECIPE_VIRTUALENV_VERSION:-${VIRTUALENV_VERSION:-20.4.5}}"
 
   # use existing virtualenv
-  virtualenv_ver="$("${PIPENV_PYTHON}" -m virtualenv --version 2>/dev/null || :)"
+  virtualenv_ver="$("${python_exe}" -m virtualenv --version 2>/dev/null || :)"
   if [ -n "${virtualenv_ver}" ]; then
     echo "Found virtualenv (${virtualenv_ver})" >&2
-    "${PIPENV_PYTHON}" -m virtualenv "${output_dir}"
+    "${python_exe}" -m virtualenv "${output_dir}"
 
   # use virtualenv zipapp
   # https://virtualenv.pypa.io/en/latest/installation.html#via-zipapp
@@ -215,14 +218,14 @@ install_pipenv()
 
       # download to file
       virtualenv_pyz="${tmp_dir}/virtualenv.pyz"
-      PYTHON="${PIPENV_PYTHON}" download_to_file "${url}" "${virtualenv_pyz}"
+      PYTHON="${python_exe}" download_to_file "${url}" "${virtualenv_pyz}"
     fi
 
     # Temp fix for https://github.com/pypa/virtualenv/issues/1949
     virtualenv_pyz="$(real_path "${virtualenv_pyz}")"
 
     # create output virtualenv
-    "${PIPENV_PYTHON}" "${virtualenv_pyz}" "${output_dir}"
+    "${python_exe}" "${virtualenv_pyz}" "${output_dir}"
 
     # cleanup
     rm -rf "${tmp_dir}" || :

--- a/30_get-pipenv
+++ b/30_get-pipenv
@@ -184,7 +184,7 @@ install_pipenv()
   local python_exe="${RECIPE_PIPENV_PYTHON:-${PIPENV_PYTHON:-"$( (command -v python3 || command -v python || command -v python2) | head -n 1)"}}"
 
   # Make sure python was found
-  if [ -n "${python_exe}" ]; then
+  if [ -z "${python_exe}" ]; then
     echo "install_pipenv cannot find python executable. Try setting RECIPE_PIPENV_PYTHON to point to python" >&2
     return 1
   fi

--- a/recipe_pipenv.Dockerfile
+++ b/recipe_pipenv.Dockerfile
@@ -2,15 +2,25 @@ FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
-ONBUILD ARG PIPENV_VERSION=2018.11.26
-ONBUILD ARG PIPENV_VIRTUALENV=/usr/local/pipenv
+ENV GET_PIPENV_FILE="/usr/local/share/just/container_build_patch/30_get-pipenv"
+ADD 30_get-pipenv "${GET_PIPENV_FILE}"
+RUN chmod 755 "${GET_PIPENV_FILE}"
+
 ONBUILD ARG PIPENV_PYTHON
-ONBUILD ARG VIRTUALENV_VERSION=20.0.33
-ADD 30_get-pipenv /usr/local/share/just/container_build_patch/30_get-pipenv
+ONBUILD ARG RECIPE_PIPENV_PYTHON="${PIPENV_PYTHON}"
+
+ONBUILD ARG PIPENV_VERSION
+ONBUILD ARG RECIPE_PIPENV_VERSION="${PIPENV_VERSION}"
+
+ONBUILD ARG PIPENV_VIRTUALENV
+ONBUILD ARG RECIPE_PIPENV_VIRTUALENV="${PIPENV_VIRTUALENV:-/usr/local/pipenv}"
+
+ONBUILD ARG VIRTUALENV_VERSION
+ONBUILD ARG RECIPE_VIRTUALENV_VERSION="${VIRTUALENV_VERSION}"
+
 # Save the arg values in the script, for use later when get-pipenv is called
-ONBUILD RUN sed -i -e "3a: \${PIPENV_PYTHON:=${PIPENV_PYTHON-}}" \
-                   -e "3a: \${PIPENV_VERSION:=${PIPENV_VERSION}}" \
-                   -e "3a: \${PIPENV_VIRTUALENV:=${PIPENV_VIRTUALENV}}" \
-                   -e "3a: \${VIRTUALENV_VERSION:=${VIRTUALENV_VERSION}}" \
-                   /usr/local/share/just/container_build_patch/30_get-pipenv; \
-            chmod 755 /usr/local/share/just/container_build_patch/30_get-pipenv
+ONBUILD RUN sed -i -e "3a: \${RECIPE_PIPENV_PYTHON:=${RECIPE_PIPENV_PYTHON}}" \
+                   -e "3a: \${RECIPE_PIPENV_VERSION:=${RECIPE_PIPENV_VERSION}}" \
+                   -e "3a: \${RECIPE_PIPENV_VIRTUALENV:=${RECIPE_PIPENV_VIRTUALENV}}" \
+                   -e "3a: \${RECIPE_VIRTUALENV_VERSION:=${RECIPE_VIRTUALENV_VERSION}}" \
+                   "${GET_PIPENV_FILE}"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       context: .
       dockerfile: test_pipenv.Dockerfile
       args:
-        PIPENV_VERSION: "2018.5.18"
+        PIPENV_VERSION: "2020.8.13"
+        VIRTUALENV_VERSION: "20.0.33"
         PIPENV_VIRTUALENV: "/foo"
         PIPENV_PYTHON: "/bar"
     image: vsiri/test_recipe:test_pipenv

--- a/tests/test-pipenv.bsh
+++ b/tests/test-pipenv.bsh
@@ -57,7 +57,15 @@ begin_test "30_get-pipenv"
     PIPENV="${OUTPUT_DIR}/bin/pipenv"
   fi
 
-  # pipenv result
+  # test for conflict with PIPENV_{FLAG_NAME} environment variables
+  # https://github.com/pypa/pipenv/blob/master/CHANGELOG.rst#features--improvements-4
+  # For example, if we define the variable
+  #   PIPENV_VERSION=2020.8.13
+  # pipenv calls will fail with the error
+  #   Error: Invalid value for '--version': 2020.8.13 is not a valid boolean
+  RESULT="$("${PIPENV}")"
+
+  # pipenv version
   RESULT="$("${PIPENV}" --version | sed 's|\r||g')"
 
   # cleanup

--- a/tests/test-pipenv.bsh
+++ b/tests/test-pipenv.bsh
@@ -15,7 +15,7 @@ begin_test "Pipenv"
   setup_test
 
   RESULT=$(docker run --rm vsiri/test_recipe:test_pipenv bash -c 'head -n1 /foo/bin/pipenv; readlink /foo/bin/python; /foo/bin/pipenv --version')
-  [ "$RESULT" = $'#!/foo/bin/python\n/bar\npipenv, version 2018.05.18' ]
+  [ "$RESULT" = $'#!/foo/bin/python\n/bar\npipenv, version 2020.8.13' ]
 
 )
 end_test
@@ -27,7 +27,7 @@ begin_test "30_get-pipenv"
   setup_test
 
   # test version
-  export PIPENV_VERSION="2020.8.13"
+  export RECIPE_PIPENV_VERSION="2020.8.13"
 
   # locale
   EN_US_UTF8="$( (locale -a | grep -iE "en_us\.utf-?8") 2>/dev/null || :)"


### PR DESCRIPTION
Fix issue #35 - we can now use `RECIPE_*` environment variables to control the pipenv recipe and/or `30_get-pipenv` script.  Note the original variables (e.g., `PIPENV_VERSION`) are kept around for backward compatibility.

Added a test that simply calls `pipenv` to ensure we do not see the error quoted in issue #35.

PR also updates the default pipenv version to 2020.11.15 and the default virtualenv version to 20.4.5.
