### PR TITLE
Update GDAL recipe to manylinux2014

### DIFF
--- a/recipe_gdal.Dockerfile
+++ b/recipe_gdal.Dockerfile
@@ -40,7 +40,7 @@
 # -----------------------------------------------------------------------------
 
 # base image
-FROM quay.io/pypa/manylinux2010_x86_64:2021-10-26-cf1e11e as base_image
+FROM quay.io/pypa/manylinux2014_x86_64:2022-02-13-594988e as base_image
 
 # Set shell to bash
 SHELL ["/usr/bin/env", "/bin/bash", "-euxvc"]
@@ -52,12 +52,13 @@ SHELL ["/usr/bin/env", "/bin/bash", "-euxvc"]
 FROM base_image as openjpeg
 
 # variables
-ENV OPENJPEG_STAGING_DIR=/openjpeg
 ENV OPENJPEG_VERSION=2.4.0
+ENV STAGING_DIR=/openjpeg
 
 # install
-RUN TEMP_DIR=/tmp/openjpeg; \
-    mkdir -p "${TEMP_DIR}"; \
+RUN TEMP_DIR="/tmp${STAGING_DIR}"; \
+    REPORT_DIR="${STAGING_DIR}/usr/local/recipe"; \
+    mkdir -p "${TEMP_DIR}" "${REPORT_DIR}"; \
     cd "${TEMP_DIR}"; \
     #
     # download & unzip
@@ -71,9 +72,8 @@ RUN TEMP_DIR=/tmp/openjpeg; \
         -DBUILD_STATIC_LIBS=OFF \
         -DCMAKE_BUILD_TYPE=Release; \
     make -j"$(nproc)"; \
-    make install DESTDIR="${OPENJPEG_STAGING_DIR}"; \
-    echo "${OPENJPEG_VERSION}" > \
-         "${OPENJPEG_STAGING_DIR}/usr/local/openjpeg_version"; \
+    make install DESTDIR="${STAGING_DIR}"; \
+    echo "${OPENJPEG_VERSION}" > "${REPORT_DIR}/openjpeg_version"; \
     #
     # cleanup
     rm -rf "${TEMP_DIR}";
@@ -85,12 +85,13 @@ RUN TEMP_DIR=/tmp/openjpeg; \
 FROM base_image as ecw
 
 # variables
-ENV ECW_STAGING_DIR=/ecw
 ENV ECW_VERSION=5.5.0
+ENV STAGING_DIR=/ecw
 
 # install
-RUN TEMP_DIR=/tmp/ecw; \
-    mkdir -p "${TEMP_DIR}"; \
+RUN TEMP_DIR="/tmp${STAGING_DIR}"; \
+    REPORT_DIR="${STAGING_DIR}/usr/local/recipe"; \
+    mkdir -p "${TEMP_DIR}" "${REPORT_DIR}"; \
     cd "${TEMP_DIR}"; \
     #
     # local variables
@@ -114,10 +115,10 @@ RUN TEMP_DIR=/tmp/ecw; \
     #
     # copy necessary files
     # this removes the "new ABI" .so files as they are note needed
-    LOCAL_DIR="${ECW_STAGING_DIR}/usr/local/ecw"; \
+    LOCAL_DIR="${STAGING_DIR}/usr/local/ecw"; \
     mkdir -p "${LOCAL_DIR}"; \
     cp -r "${UNPACK_DIR}"/{*.txt,bin,etc,include,lib,third*} "${LOCAL_DIR}"; \
-    echo "${ECW_VERSION}" > "${ECW_STAGING_DIR}/usr/local/ecw_version"; \
+    echo "${ECW_VERSION}" > "${REPORT_DIR}/ecw_version"; \
     #
     # remove the "new C++11 ABI"
     rm -rf "${LOCAL_DIR}"/{lib/cpp11abi,lib/newabi} \
@@ -127,8 +128,8 @@ RUN TEMP_DIR=/tmp/ecw; \
     rm -r "${TEMP_DIR}" "${UNPACK_DIR}";
 
 # link .so files to "/usr/local/lib" for easier discovery
-RUN mkdir -p "${ECW_STAGING_DIR}/usr/local/lib"; \
-    cd "${ECW_STAGING_DIR}/usr/local/lib"; \
+RUN mkdir -p "${STAGING_DIR}/usr/local/lib"; \
+    cd "${STAGING_DIR}/usr/local/lib"; \
     ln -s ../ecw/lib/x64/release/libNCSEcw.so* .;
 
 
@@ -139,8 +140,8 @@ RUN mkdir -p "${ECW_STAGING_DIR}/usr/local/lib"; \
 FROM base_image as tiff
 
 # variables
-ENV TIFF_STAGING_DIR=/tiff
 ENV TIFF_VERSION=4.3.0
+ENV STAGING_DIR=/tiff
 
 # additional build dependencies
 RUN yum install -y \
@@ -149,20 +150,23 @@ RUN yum install -y \
     yum clean all
 
 # install
-RUN TEMP_DIR=/tmp/tiff; \
-    mkdir -p "${TEMP_DIR}"; \
+RUN TEMP_DIR="/tmp${STAGING_DIR}"; \
+    REPORT_DIR="${STAGING_DIR}/usr/local/recipe"; \
+    mkdir -p "${TEMP_DIR}" "${REPORT_DIR}"; \
     cd "${TEMP_DIR}"; \
     #
     # download & unzip
     TAR_FILE="tiff-${TIFF_VERSION}.tar.gz"; \
-    curl -fsSLO "http://download.osgeo.org/libtiff/${TAR_FILE}"; \
+    curl -fsSLO "https://download.osgeo.org/libtiff/${TAR_FILE}"; \
     tar -xf "${TAR_FILE}" --strip-components=1; \
     #
     # configure, build, & install
-    ./configure; \
+    ./configure \
+        --disable-static \
+        | tee "${REPORT_DIR}/tiff_configure"; \
     make -j"$(nproc)"; \
-    make install DESTDIR="${TIFF_STAGING_DIR}"; \
-    echo "$TIFF_VERSION" > "${TIFF_STAGING_DIR}/usr/local/tiff_version"; \
+    make install DESTDIR="${STAGING_DIR}"; \
+    echo "$TIFF_VERSION" > "${REPORT_DIR}/tiff_version"; \
     #
     # cleanup
     rm -r "${TEMP_DIR}";
@@ -175,8 +179,8 @@ RUN TEMP_DIR=/tmp/tiff; \
 FROM base_image as proj
 
 # variables
-ENV PROJ_STAGING_DIR=/proj
 ENV PROJ_VERSION=8.1.1
+ENV STAGING_DIR=/proj
 
 # additional build dependencies
 RUN yum install -y \
@@ -189,23 +193,25 @@ RUN yum install -y \
 COPY --from=tiff /tiff/usr/local /usr/local
 
 # install
-RUN TEMP_DIR=/tmp/proj; \
-    mkdir -p "${TEMP_DIR}"; \
+RUN TEMP_DIR="/tmp${STAGING_DIR}"; \
+    REPORT_DIR="${STAGING_DIR}/usr/local/recipe"; \
+    mkdir -p "${TEMP_DIR}" "${REPORT_DIR}"; \
     cd "${TEMP_DIR}"; \
     #
     # download & unzip
     TAR_FILE="proj-${PROJ_VERSION}.tar.gz"; \
-    curl -fsSLO http://download.osgeo.org/proj/${TAR_FILE}; \
+    curl -fsSLO "https://download.osgeo.org/proj/${TAR_FILE}"; \
     tar -xf ${TAR_FILE} --strip-components=1; \
     #
     # configure, build, & install
     ./configure \
         CFLAGS='-DPROJ_RENAME_SYMBOLS -O2' \
         CXXFLAGS='-DPROJ_RENAME_SYMBOLS -DPROJ_INTERNAL_CPP_NAMESPACE -O2' \
-        --disable-static; \
+        --disable-static \
+        | tee "${REPORT_DIR}/proj_configure"; \
     make -j"$(nproc)"; \
-    make install "DESTDIR=${PROJ_STAGING_DIR}"; \
-    echo "${PROJ_VERSION}" > "${PROJ_STAGING_DIR}/usr/local/proj_version"; \
+    make install "DESTDIR=${STAGING_DIR}"; \
+    echo "${PROJ_VERSION}" > "${REPORT_DIR}/proj_version"; \
     #
     # cleanup
     rm -r "${TEMP_DIR}";
@@ -218,8 +224,8 @@ RUN TEMP_DIR=/tmp/proj; \
 FROM base_image as geotiff
 
 # variables
-ENV GEOTIFF_STAGING_DIR=/geotiff
 ENV GEOTIFF_VERSION=1.7.0
+ENV STAGING_DIR=/geotiff
 
 # additional build dependencies
 RUN yum install -y \
@@ -233,24 +239,26 @@ COPY --from=tiff /tiff/usr/local /usr/local
 COPY --from=proj /proj/usr/local /usr/local
 
 # install
-RUN TEMP_DIR="/tmp/geotiff"; \
-    mkdir -p "${TEMP_DIR}"; \
+RUN TEMP_DIR="/tmp${STAGING_DIR}"; \
+    REPORT_DIR="${STAGING_DIR}/usr/local/recipe"; \
+    mkdir -p "${TEMP_DIR}" "${REPORT_DIR}"; \
     cd "${TEMP_DIR}"; \
     mkdir -p "./source" "./build"; \
     #
     # download & unzip
     TAR_FILE="libgeotiff-${GEOTIFF_VERSION}.tar.gz"; \
-    curl -fsSLO "http://download.osgeo.org/geotiff/libgeotiff/${TAR_FILE}"; \
+    curl -fsSLO "https://download.osgeo.org/geotiff/libgeotiff/${TAR_FILE}"; \
     tar -xf "${TAR_FILE}" --strip-components=1; \
     #
     # configure, build, & install
     ./configure \
         --with-jpeg \
         --with-proj=/usr/local \
-        --with-zlib; \
+        --with-zlib \
+        | tee "${REPORT_DIR}/geotiff_configure"; \
     make -j"$(nproc)"; \
-    make install DESTDIR="${GEOTIFF_STAGING_DIR}"; \
-    echo "$GEOTIFF_VERSION" > "${GEOTIFF_STAGING_DIR}/usr/local/geotiff_version"; \
+    make install DESTDIR="${STAGING_DIR}"; \
+    echo "$GEOTIFF_VERSION" > "${REPORT_DIR}/geotiff_version"; \
     #
     # cleanup
     rm -r "${TEMP_DIR}";
@@ -262,16 +270,23 @@ RUN TEMP_DIR="/tmp/geotiff"; \
 FROM base_image
 
 # variables
-ENV GDAL_STAGING_DIR=/gdal
+ENV STAGING_DIR=/gdal
+
+# additional build dependencies
+RUN yum install -y \
+      libcurl-devel \
+      libjpeg-turbo-devel \
+      zlib-devel; \
+    yum clean all
 
 # local dependencies to staging directory
 # the base_image has many other dependencies already in /usr/local,
 # so we isolate packages in a staging directory
-COPY --from=openjpeg /openjpeg ${GDAL_STAGING_DIR}
-COPY --from=ecw /ecw ${GDAL_STAGING_DIR}
-COPY --from=tiff /tiff ${GDAL_STAGING_DIR}
-COPY --from=proj /proj ${GDAL_STAGING_DIR}
-COPY --from=geotiff /geotiff ${GDAL_STAGING_DIR}
+COPY --from=openjpeg /openjpeg ${STAGING_DIR}
+COPY --from=ecw /ecw ${STAGING_DIR}
+COPY --from=tiff /tiff ${STAGING_DIR}
+COPY --from=proj /proj ${STAGING_DIR}
+COPY --from=geotiff /geotiff ${STAGING_DIR}
 
 # local dependencies to /usr/local
 # This is necessary only for those dependencies expected to be in a "normal"
@@ -280,24 +295,25 @@ COPY --from=geotiff /geotiff ${GDAL_STAGING_DIR}
 COPY --from=openjpeg /openjpeg/usr/local /usr/local
 
 # add staged libraries
-ENV LD_LIBRARY_PATH="${GDAL_STAGING_DIR}/usr/local/lib"
+ENV LD_LIBRARY_PATH="${STAGING_DIR}/usr/local/lib"
 
 # Patch file for downstream image
-ENV GDAL_PATCH_FILE=${GDAL_STAGING_DIR}/usr/local/share/just/container_build_patch/30_gdal
+ENV GDAL_PATCH_FILE=${STAGING_DIR}/usr/local/share/just/container_build_patch/30_gdal
 ADD 30_gdal ${GDAL_PATCH_FILE}
 RUN chmod +x ${GDAL_PATCH_FILE}
 
 # install
-ONBUILD ARG GDAL_VERSION=3.2.3
+ONBUILD ARG GDAL_VERSION=3.3.3
 
-ONBUILD \
-RUN TEMP_DIR=/tmp/gdal; \
-    mkdir -p "${TEMP_DIR}"; \
+ONBUILD RUN \
+    TEMP_DIR="/tmp${STAGING_DIR}"; \
+    REPORT_DIR="${STAGING_DIR}/usr/local/recipe"; \
+    mkdir -p "${TEMP_DIR}" "${REPORT_DIR}"; \
     cd "${TEMP_DIR}"; \
     #
     # download & unzip
     TAR_FILE="gdal-${GDAL_VERSION}.tar.gz"; \
-    curl -fsSLO "http://download.osgeo.org/gdal/${GDAL_VERSION}/${TAR_FILE}"; \
+    curl -fsSLO "https://download.osgeo.org/gdal/${GDAL_VERSION}/${TAR_FILE}"; \
     tar -xf "${TAR_FILE}" --strip-components=1; \
     #
     # configure, build, & install
@@ -307,21 +323,23 @@ RUN TEMP_DIR=/tmp/gdal; \
         --with-hide-internal-symbols \
         --with-jpeg=internal \
         --with-png=internal \
-        --with-libtiff=${GDAL_STAGING_DIR}/usr/local \
-        --with-geotiff=${GDAL_STAGING_DIR}/usr/local \
+        --with-pcre=no \
+        --with-libtiff="${STAGING_DIR}/usr/local" \
+        --with-geotiff="${STAGING_DIR}/usr/local" \
         --with-openjpeg \
-        --with-proj="${GDAL_STAGING_DIR}/usr/local" \
-        --with-ecw="${GDAL_STAGING_DIR}/usr/local/ecw" \
-        | tee "${GDAL_STAGING_DIR}/usr/local/gdal_configure"; \
+        --with-proj="${STAGING_DIR}/usr/local" \
+        --with-ecw="${STAGING_DIR}/usr/local/ecw" \
+        | tee "${REPORT_DIR}/gdal_configure"; \
+    # cat "${TEMP_DIR}/config.log"; \
     #
     # build & install
     make -j "$(nproc)"; \
-    make install "DESTDIR=${GDAL_STAGING_DIR}"; \
-    echo "${GDAL_VERSION}" > "${GDAL_STAGING_DIR}/usr/local/gdal_version"; \
+    make install "DESTDIR=${STAGING_DIR}"; \
+    echo "${GDAL_VERSION}" > "${REPORT_DIR}/gdal_version"; \
     #
     # cleanup
     rm -r "${TEMP_DIR}";
 
 # migrate staging directory to /usr/local
 ONBUILD RUN rm -rf /usr/local; \
-            mv "${GDAL_STAGING_DIR}/usr/local" /usr/local
+            mv "${STAGING_DIR}/usr/local" /usr/local

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       context: .
       dockerfile: test_gdal.Dockerfile
       args:
-        GDAL_VERSION: "3.2.3"
+        GDAL_VERSION: "3.3.3"
     image: vsiri/test_recipe:test_gdal
   test_git-lfs:
     build:

--- a/tests/test-gdal.bsh
+++ b/tests/test-gdal.bsh
@@ -19,11 +19,11 @@ begin_test "GDAL"
 
   # command line GDAL version
   RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'gdalinfo --version')"
-  [ "${RESULT}" = 'GDAL 3.2.3, released 2021/04/27' ]
+  [ "${RESULT}" = 'GDAL 3.3.3, released 2021/10/25' ]
 
   # python GDAL version
   RESULT="$(docker run --rm ${DOCKER_IMAGE} python -c 'from osgeo import gdal; print(gdal.__version__)')"
-  [ "${RESULT}" = '3.2.3' ]
+  [ "${RESULT}" = '3.3.3' ]
 
   # test python import (for example, gdal_array may fail to import if numpy is not installed)
   docker run --rm ${DOCKER_IMAGE} python -c 'from osgeo import gdal, ogr, osr, gdal_array, gdalconst'

--- a/tests/test_gdal.Dockerfile
+++ b/tests/test_gdal.Dockerfile
@@ -3,8 +3,13 @@ FROM python:3.8
 COPY --from=gdal /usr/local /usr/local
 
 # numpy must be installed before GDAL python bindings
-RUN pip install numpy ; \
-    pip install GDAL==$(cat /usr/local/gdal_version) ;
+RUN pip install numpy;
+
+# install GDAL with specific compiler flags
+# GDAL is built in in a manylinux container using the old C++ ABI.
+# Ensure the gdal wheel is built from source using the same ABI.
+RUN GDAL_VERSION=$(cat /usr/local/recipe/gdal_version); \
+    CFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" pip install GDAL==${GDAL_VERSION};
 
 # Only needs to be run once for all recipes
 RUN for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done

--- a/tests/test_gdal.Dockerfile
+++ b/tests/test_gdal.Dockerfile
@@ -8,7 +8,7 @@ RUN pip install numpy;
 # install GDAL with specific compiler flags
 # GDAL is built in in a manylinux container using the old C++ ABI.
 # Ensure the gdal wheel is built from source using the same ABI.
-RUN GDAL_VERSION=$(cat /usr/local/recipe/gdal_version); \
+RUN GDAL_VERSION=$(cat /usr/local/share/just/info/gdal_version); \
     CFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" pip install GDAL==${GDAL_VERSION};
 
 # Only needs to be run once for all recipes


### PR DESCRIPTION
- migrate gdal recipe to manylinux2014/centos7 (manylinux dropping support for manylinux2010/centos6)
- GDAL default to 3.3.3
- https download for download.osgeo locations
- store versions & configure information in `$STAGING/usr/local/recipe`