### PR TITLE
pipenv default version

### DIFF
--- a/30_get-pipenv
+++ b/30_get-pipenv
@@ -175,9 +175,9 @@ fi
 #
 # :Arguments: [``$1``] - The location of the virtualenv, defaults to ``${RECIPE_PIPENV_VIRTUALENV-${PIPENV_VIRTUALENV-${HOME}/pipenv}}``
 # :Parameters: * ``RECIPE_PIPENV_PYTHON`` or ``PIPENV_PYTHON`` - Optionally specify which python you want to use. Default is to favor python3, trying ``python3``, ``python``, then finally falling back to ``python2``.
-#              * ``RECIPE_PIPENV_VERSION`` or ``PIPENV_VERSION`` - The version of pipenv to install, defaults - ``2020.11.15``
+#              * ``RECIPE_PIPENV_VERSION`` or ``PIPENV_VERSION`` - The version of pipenv to install, defaults - ``2022.1.8``
 #              * ``RECIPE_VIRTUALENV_PYZ`` or ``VIRTUALENV_PYZ`` - Name of downloaded ``virtualenv.pyz``, else it will attempt to download it itself.
-#              * ``RECIPE_VIRTUALENV_VERSION`` or ``VIRTUALENV_VERSION`` - The version of virtualenv to use, affecting both the virtualenv zipapp version and the virtualenv version used by pipenv environment.  defaults to ``20.4.5``
+#              * ``RECIPE_VIRTUALENV_VERSION`` or ``VIRTUALENV_VERSION`` - The version of virtualenv to use, affecting both the virtualenv zipapp version and the virtualenv version used by pipenv environment.  defaults to ``20.13.3``
 #
 #**
 install_pipenv()
@@ -193,9 +193,9 @@ install_pipenv()
 
   # setup
   local output_dir="${1-${RECIPE_PIPENV_VIRTUALENV-${PIPENV_VIRTUALENV-${HOME}/pipenv}}}"
-  local pipenv_ver="${RECIPE_PIPENV_VERSION:-${PIPENV_VERSION:-2020.11.15}}"
+  local pipenv_ver="${RECIPE_PIPENV_VERSION:-${PIPENV_VERSION:-2022.1.8}}"
   local virtualenv_pyz="${RECIPE_VIRTUALENV_PYZ:-${VIRTUALENV_PYZ:-}}"
-  local virtualenv_version="${RECIPE_VIRTUALENV_VERSION:-${VIRTUALENV_VERSION:-20.4.5}}"
+  local virtualenv_version="${RECIPE_VIRTUALENV_VERSION:-${VIRTUALENV_VERSION:-20.13.3}}"
 
   # use existing virtualenv
   virtualenv_ver="$("${python_exe}" -m virtualenv --version 2>/dev/null || :)"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       context: .
       dockerfile: test_pipenv.Dockerfile
       args:
-        PIPENV_VERSION: "2020.8.13"
-        VIRTUALENV_VERSION: "20.0.33"
+        PIPENV_VERSION: "2021.11.23"
+        VIRTUALENV_VERSION: "20.13.3"
         PIPENV_VIRTUALENV: "/foo"
         PIPENV_PYTHON: "/bar"
     image: vsiri/test_recipe:test_pipenv

--- a/tests/test-pipenv.bsh
+++ b/tests/test-pipenv.bsh
@@ -17,7 +17,7 @@ begin_test "Pipenv"
   setup_test
 
   RESULT="$(docker run --rm vsiri/test_recipe:test_pipenv bash -c 'head -n1 /foo/bin/pipenv; readlink /foo/bin/python; /foo/bin/pipenv --version')"
-  [ "${RESULT}" = $'#!/foo/bin/python\n/bar\npipenv, version 2020.8.13' ]
+  [ "${RESULT}" = $'#!/foo/bin/python\n/bar\npipenv, version 2021.11.23' ]
 
 )
 end_test
@@ -31,7 +31,7 @@ begin_test "30_get-pipenv"
   setup_test
 
   # test version
-  export RECIPE_PIPENV_VERSION="2020.8.13"
+  export RECIPE_PIPENV_VERSION="2021.11.23"
 
   # locale
   EN_US_UTF8="$( (locale -a | grep -iE "en_us\.utf-?8") 2>/dev/null || :)"
@@ -76,7 +76,7 @@ begin_test "30_get-pipenv"
   rm -rf "${OUTPUT_DIR}"
 
   # test
-  [ "${RESULT}" = 'pipenv, version 2020.8.13' ]
+  [ "${RESULT}" = 'pipenv, version 2021.11.23' ]
 )
 end_test
 


### PR DESCRIPTION
- 30_get-pipenv update default pipenv to 2022.1.8 and default virtualenv to 20.13.3
- pipenv test use recent pipenv version
