### PR TITLE
circleci missing cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,11 +73,23 @@ commands:
 
             # ci_load for each service
             for SERVICE in "${SERVICES[@]}"; do
+
+              # per service options
+              _ci_load_options="${CI_LOAD_OPTIONS}"
+
+              # if final image does not exist in cache, disable pull
+              # this allow new recipes to be built without a cache
+              _image="${CI_RECIPE_REPO}:${SERVICE}_final"
+              if ! docker manifest inspect "${_image}" &>/dev/null; then
+                _ci_load_options+=" --no-pull"
+              fi
+
+              # run ci_load
               python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
                 --recipe-repo "IGNORE" \
-                ${CI_RECIPE_REPO:+ --cache-repo "${CI_RECIPE_REPO}"} \
+                --cache-repo "${CI_RECIPE_REPO}" \
                 ${CI_RECIPE_VERSION:+ --cache-version "${CI_RECIPE_VERSION}"} \
-                ${CI_LOAD_OPTIONS:+ ${CI_LOAD_OPTIONS}} \
+                ${_ci_load_options} \
                 "${COMPOSE_FILE}" "${SERVICE}"
             done
 


### PR DESCRIPTION
In CircleCI, when the dockerhub recipe cache does not exist `ci_load` fails with the error below.  This can happen for a new image without a valid cache, or an existing image if the cache was deleted.

Check for the cache existence using `docker manifest inspect ${CI_RECIPE_REPO}:${SERVICE}_final` and include `--no-pull` in `ci_load` options if image does not exist.

Example failure for new multi-stage recipe:
```
[+] Running 0/7
 ⠿ stage_gdal Error        0.5s
 ⠿ stage_lazperf Error     0.5s
 ⠿ final_pdal Error        0.5s
 ⠿ stage_laszip Error      0.5s
 ⠿ stage_pdal Error        0.5s
 ⠿ stage_nitro Error       0.5s
 ⠿ stage_base_image Error  0.5s
WARNING: Some service image(s) must be built from source by running:
    docker compose build final_pdal stage_base_image stage_nitro stage_lazperf stage_gdal stage_laszip stage_pdal
Error response from daemon: manifest for vsiri/ci_cache_recipes:pdal_final not found
Traceback (most recent call last):
  File "/home/circleci/vsi/linux/ci_load.py", line 322, in <module>
    ci_load.pull_images()
  File "/home/circleci/vsi/linux/ci_load.py", line 110, in pull_images
    Popen2([self.docker_compose_exe,
  File "/home/circleci/vsi/linux/ci_load.py", line 37, in Popen2
    assert pid.returncode == 0
AssertionError
```
