### PR TITLE
recipe_proj-data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -394,6 +394,31 @@ This is the easiest way to install an arbitrary version of python on an arbitrar
    COPY --from=python /usr/local /usr/local
 
 
+PROJ-data
+---------
+
+============ ============
+Name         PROJ-data
+Build Args   ``PROJ_DATA_VERSION`` - Version of proj-data to download
+Output dir   ``/usr/local``
+============ ============
+
+This is a recipe for installing `PROJ-data <https://github.com/OSGeo/PROJ-data>`_, a very large (over 500MB) plugin for the `PROJ <https://github.com/OSGeo/PROJ>`_ package. PROJ-data contains a variety of datum grid files necessary for horizontal and vertical coordinate transformations.
+
+PROJ-data files are fully optional, and only downloaded and installed ``PROJ_DATA_VERSION`` is set.
+
+Users may alternatively make use of `remotely hosted PROJ-data <https://proj.org/usage/network.html>`_ to avoid installation of this large package.
+
+.. rubric:: Example
+
+.. code-block:: Dockerfile
+
+   FROM vsiri/recipe:proj-data as proj-data
+   FROM ubuntu:16.04
+   RUN apt-get update; apt-get install -y vim  # This line is just an example
+   COPY --from=proj-data /usr/local /usr/local
+
+
 J.U.S.T.
 ========
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,3 +114,12 @@ services:
       # args:
       #   PYTHON_VERSION: "${PYTHON_VERSION}"
     image: vsiri/recipe:conda-python
+
+  proj-data:
+    build:
+    build:
+      context: .
+      dockerfile: recipe_proj-data.Dockerfile
+      # args:
+      #   PROJ_DATA_VERSION: "${PYTHON_VERSION}"
+    image: vsiri/recipe:proj-data

--- a/recipe_proj-data.Dockerfile
+++ b/recipe_proj-data.Dockerfile
@@ -1,0 +1,21 @@
+# optionally install proj-data (over 500MB) useful for certain PROJ datum transformations
+# https://github.com/OSGeo/PROJ-data
+# Users may avoid this large install by alternatively using remotely hosted proj-data
+# https://proj.org/usage/network.html
+FROM alpine:3.11.8
+
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
+
+ONBUILD ARG PROJ_DATA_VERSION=
+ONBUILD ARG PROJ_DATA_DIR="/usr/local/share/proj"
+#No signature :(
+ONBUILD RUN apk add --no-cache --virtual .deps curl ca-certificates; \
+            mkdir -p "${PROJ_DATA_DIR}"; \
+            cd "${PROJ_DATA_DIR}"; \
+            if [ -n "${PROJ_DATA_VERSION-}" ]; then \
+                TAR_FILE="proj-data-${PROJ_DATA_VERSION}.tar.gz"; \
+                curl -fsSLO "https://download.osgeo.org/proj/${TAR_FILE}"; \
+                tar -xf "${TAR_FILE}"; \
+                rm "${TAR_FILE}"; \
+            fi; \
+            apk del .deps


### PR DESCRIPTION
new recipe for proj-data, a very large (over 500MB) plugin for the PROJ package containing a variety of datum grid files necessary for horizontal and vertical coordinate transformations. 