### PR TITLE
Make the man dir work in build kit

### DIFF
--- a/recipe_cmake.Dockerfile
+++ b/recipe_cmake.Dockerfile
@@ -18,6 +18,10 @@ ONBUILD RUN apk add --no-cache --virtual .deps unzip curl ca-certificates; \
             tar xf "/cmake-${CMAKE_VERSION}-${os_name}.tar.gz"; \
             rm -r /usr/local/*; \
             mv "/cmake-${CMAKE_VERSION}-${os_name}"/* /usr/local/; \
+            if [ -d "/usr/local/man" ]; then \
+              mkdir -p /usr/local/share; \
+              mv /usr/local/man /usr/local/share/; \
+            fi; \
             rmdir "/cmake-${CMAKE_VERSION}-${os_name}"; \
             rm "/cmake-${CMAKE_VERSION}-${os_name}.tar.gz"; \
             apk del .deps


### PR DESCRIPTION
- Buildkit is less forgiving about directories replacing symlinks, and errors
- Further the symlink isn't followed to share/man, like we'd want it to, so
  we manually move the files to where they belong

Signed-off-by: Andy Neff <andy@visionsystemsinc.com>