### PR TITLE
Cuda ubuntu fix

### DIFF
--- a/30_install_cuda
+++ b/30_install_cuda
@@ -128,72 +128,86 @@ EOF
   yum install --setopt=obsoletes=0 -y "${packages[@]}"
   rm -rf /var/cache/yum/*
 elif command -v apt-get 2>&1 > /dev/null; then
+  source /etc/os-release
+  ubuntu_major_version=${VERSION_ID%%.*}
+
   ########
   # Base #
   ########
 
-  source /etc/os-release
-  ubuntu_major_version=${VERSION_ID%%.*}
-
-  apt-key add /usr/local/share/just/info/cuda/keys/*
-  echo "deb deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${ubuntu_major_version}04/${NVARCH} /" > /etc/apt/sources.list.d/cuda.list
-
-  packages+=(${NV_CUDA_COMPAT_PACKAGE-cuda-compat-${cuda_version[0]}-${cuda_version[1]}}
-             cuda-cudart-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_CUDART_VERSION})
+  if [ "${install_base}" = "1" ]; then
+    packages+=(${NV_CUDA_COMPAT_PACKAGE-cuda-compat-${cuda_version[0]}-${cuda_version[1]}}
+               cuda-cudart-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_CUDART_VERSION})
+  fi
 
   ###########
   # Runtime #
   ###########
 
-  if [ "${cuda_version[0]}" = "10" ]; then
-    packages+=(${NV_LIBCUSPARSE_VERSION+cuda-cusparse-${cuda_version[0]}-${cuda_version[1]}=${NV_LIBCUSPARSE_VERSION}})
-  else
-    packages+=(${NV_LIBCUSPARSE_VERSION+libcusparse-11-0=${NV_LIBCUSPARSE_VERSION}})
-  fi
+  if [ "${install_runtime}" = "1" ]; then
+    if [ "${cuda_version[0]}" = "10" ]; then
+      packages+=(${NV_LIBCUSPARSE_VERSION+cuda-cusparse-${cuda_version[0]}-${cuda_version[1]}=${NV_LIBCUSPARSE_VERSION}})
+    else
+      packages+=(${NV_LIBCUSPARSE_VERSION+libcusparse-${cuda_version[0]}-${cuda_version[1]}=${NV_LIBCUSPARSE_VERSION}})
+    fi
 
-  packages+=(${NV_CUDA_LIB_VERSION+cuda-libraries-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_LIB_VERSION}}
-             ${NV_LIBNPP_PACKAGE-${NV_LIBNPP_VERSION+cuda-npp-10-0=${NV_LIBNPP_VERSION}}}
-             ${NV_NVTX_VERSION+cuda-nvtx-${cuda_version[0]}-${cuda_version[1]}=${NV_NVTX_VERSION}}
-             ${NV_LIBCUBLAS_PACKAGE-}
-             ${NV_LIBNCCL_PACKAGE-})
+    packages+=(${NV_CUDA_LIB_VERSION+cuda-libraries-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_LIB_VERSION}}
+              ${NV_LIBNPP_PACKAGE-${NV_LIBNPP_VERSION+cuda-npp-10-0=${NV_LIBNPP_VERSION}}}
+              ${NV_NVTX_VERSION+cuda-nvtx-${cuda_version[0]}-${cuda_version[1]}=${NV_NVTX_VERSION}}
+              ${NV_LIBCUBLAS_PACKAGE-}
+              ${NV_LIBNCCL_PACKAGE-})
 
-  #################
-  # Runtime cudnn # Won't work on the older CUDAs
-  #################
+    #################
+    # Runtime cudnn # Won't work on the older CUDAs
+    #################
 
-  if [ -n "${CUDNN_VERSION:+set}" ]; then
-    packages+=(${NV_CUDNN_PACKAGE})
+    if [ -n "${CUDNN_VERSION:+set}" ]; then
+      packages+=(${NV_CUDNN_PACKAGE})
+    fi
   fi
 
   #########
   # Devel # Not accurate for older CUDAs
   #########
 
-  packages+=(libtinfo5 libncursesw5
-             ${NV_CUDA_CUDART_DEV_VERSION+cuda-cudart-dev-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_CUDART_DEV_VERSION}}
-             ${NV_CUDA_LIB_VERSION+cuda-command-line-tools-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_LIB_VERSION}}
-             ${NV_CUDA_LIB_VERSION+cuda-minimal-build-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_LIB_VERSION}}
-             ${NV_CUDA_LIB_VERSION+cuda-libraries-dev-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_LIB_VERSION}}
-             ${NV_NVML_DEV_VERSION+cuda-nvml-dev-${cuda_version[0]}-${cuda_version[1]}=${NV_NVML_DEV_VERSION}}
-             ${NV_NVPROF_DEV_PACKAGE-}
-             ${NV_LIBNPP_DEV_PACKAGE-}
-             ${NV_LIBCUSPARSE_DEV_VERSION+libcusparse-dev-${cuda_version[0]}-${cuda_version[1]}=${NV_LIBCUSPARSE_DEV_VERSION}}
-             ${NV_LIBCUBLAS_DEV_PACKAGE-}
-             ${NV_LIBNCCL_DEV_PACKAGE-})
+  if [ "${install_devel}" = "1" ]; then
+    packages+=(libtinfo5 libncursesw5
+              ${NV_CUDA_CUDART_DEV_VERSION+cuda-cudart-dev-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_CUDART_DEV_VERSION}}
+              ${NV_CUDA_LIB_VERSION+cuda-command-line-tools-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_LIB_VERSION}}
+              ${NV_CUDA_LIB_VERSION+cuda-minimal-build-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_LIB_VERSION}}
+              ${NV_CUDA_LIB_VERSION+cuda-libraries-dev-${cuda_version[0]}-${cuda_version[1]}=${NV_CUDA_LIB_VERSION}}
+              ${NV_NVML_DEV_VERSION+cuda-nvml-dev-${cuda_version[0]}-${cuda_version[1]}=${NV_NVML_DEV_VERSION}}
+              ${NV_NVPROF_DEV_PACKAGE-}
+              ${NV_LIBNPP_DEV_PACKAGE-}
+              ${NV_LIBCUSPARSE_DEV_VERSION+libcusparse-dev-${cuda_version[0]}-${cuda_version[1]}=${NV_LIBCUSPARSE_DEV_VERSION}}
+              ${NV_LIBCUBLAS_DEV_PACKAGE-}
+              ${NV_LIBNCCL_DEV_PACKAGE-})
 
-  ###############
-  # Devel cudnn # Won't work on the older CUDAs
-  ###############
+    ###############
+    # Devel cudnn # Won't work on the older CUDAs
+    ###############
 
-  if [ -n "${CUDNN_VERSION:+set}" ]; then
-    packages+=(${NV_CUDNN_PACKAGE} ${NV_CUDNN_PACKAGE_DEV})
+    if [ -n "${CUDNN_VERSION:+set}" ]; then
+      packages+=(${NV_CUDNN_PACKAGE} ${NV_CUDNN_PACKAGE_DEV})
+    fi
   fi
 
   ###########
   # Install #
   ###########
 
+  # The nvidia repo can't be downloaded without this.
+  if ! dpkg -s ca-certificates &> /dev/null; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates
+  fi
+
+  # The "new" way to add a repo and key since at least 16.04
+  cat /usr/local/share/just/info/cuda/keys/* > /usr/share/keyrings/cuda.asc
+  echo "deb [signed-by=/usr/share/keyrings/cuda.asc] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${ubuntu_major_version}04/${NVARCH} /" > /etc/apt/sources.list.d/cuda.list
+
   apt-get update
+
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${packages[@]}"
   apt-mark hold ${NV_LIBCUBLAS_DEV_PACKAGE_NAME-} ${NV_LIBNCCL_DEV_PACKAGE_NAME-} || :
   rm -rf /var/lib/apt/lists/*

--- a/40_install_cudagl
+++ b/40_install_cudagl
@@ -136,6 +136,7 @@ elif command -v apt-get 2>&1 > /dev/null; then
   fi
 
   if [ "${#packages[@]}" -ne "0" ]; then
+    dpkg --add-architecture i386
     apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${packages[@]}"
     rm -rf /var/lib/apt/lists/*

--- a/README.rst
+++ b/README.rst
@@ -406,8 +406,10 @@ The ``CUDA_VERSION``/``CUDNN_VERSION`` build args must be limited to the version
    COPY --from=cuda /usr/local /usr/local
    # Only needs to be run once for all recipes
    RUN for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
-   ENV NVIDIA_VISIBLE_DEVICES=all # Required for this recipe
-   ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility # Optional: compute,utility is the default if unset
+   # Required for this recipe
+   ENV NVIDIA_VISIBLE_DEVICES=all
+   # NVIDIA_DRIVER_CAPABILITIES is optional, but not setting it results in compute,utility
+   ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
    # (Uncommon) If you need all the nvidia environment variables, source this file
    RUN source /usr/local/share/just/user_run_patch/10_load_cuda_env; \

--- a/recipe_cuda.Dockerfile
+++ b/recipe_cuda.Dockerfile
@@ -8,8 +8,7 @@ SHELL ["/usr/bin/env", "bash", "-euxvc"]
 # This ADD can be commented out to skip the test
 ADD https://gitlab.com/api/v4/projects/2330984/repository/branches/master /cuda-master.json
 
-# ARG CUDA_REPO_REF=a07cb97de5798b75147cbe1158c6caadffee2892
-ARG CUDA_REPO_REF=5bc8c5483115b8e9c68d4f1280acb8d56196d681
+ARG CUDA_REPO_REF=a07cb97de5798b75147cbe1158c6caadffee2892
 RUN if [ -f "/cuda-master.json" ]; then \
       new_master_ref="$(sed 's|.*"id":"\([^"]*\).*|\1|' /cuda-master.json)"; \
       rm /cuda-master.json; \

--- a/recipe_cuda.Dockerfile
+++ b/recipe_cuda.Dockerfile
@@ -8,6 +8,7 @@ SHELL ["/usr/bin/env", "bash", "-euxvc"]
 # This ADD can be commented out to skip the test
 ADD https://gitlab.com/api/v4/projects/2330984/repository/branches/master /cuda-master.json
 
+# ARG CUDA_REPO_REF=a07cb97de5798b75147cbe1158c6caadffee2892
 ARG CUDA_REPO_REF=5bc8c5483115b8e9c68d4f1280acb8d56196d681
 RUN if [ -f "/cuda-master.json" ]; then \
       new_master_ref="$(sed 's|.*"id":"\([^"]*\).*|\1|' /cuda-master.json)"; \

--- a/recipe_cudagl.Dockerfile
+++ b/recipe_cudagl.Dockerfile
@@ -85,7 +85,7 @@ COPY --from=ubi8 /usr/local/lib64 /usr/local/share/just/info/rhel8/lib64
 # COPY --from=ubi9 /usr/local/lib64 /usr/local/share/just/info/rhel8/lib64
 
 ADD --chmod=644 10_load_cuda_env /usr/local/share/just/user_run_patch/
-ADD --chmod=755 30_ldconfig 30_install_cudagl /usr/local/share/just/container_build_patch/
+ADD --chmod=755 30_ldconfig 40_install_cudagl /usr/local/share/just/container_build_patch/
 ADD --chmod=755 10_sideload_rocky /usr/local/share/just/scripts/
 
 COPY <<EOF /usr/local/share/glvnd/egl_vendor.d/10_nvidia.json


### PR DESCRIPTION
- Apparently the ubuntu code path was never tested, not even once
- Replace deprecated "apt-key add" with the modern way. This works back to
  Ubuntu 16.04, so seems good enough
- Add proper CUDA_RECIPE_TARGET gates for ubuntu on cuda install. They were all
  missing, and always installing everything
- Fix libcusparse accidentally being hardcoded to 11.0 instead of just 11
- Fix bad use of # in readme example
- Made sure cudagl was installed after cuda base on number instead of alphabet
- Enable 32 bit packages on cudagl cause that's what Nvidia does. Maybe add
  that as option in the future
- Updated the master sha to get rid of an annoying message