### PR TITLE
rocky vault

### DIFF
--- a/10_sideload_rocky
+++ b/10_sideload_rocky
@@ -7,12 +7,9 @@ function install_rocky_repo()
   # Alternative: If using the direct url gets slow, use the mirror list:
   # https://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=rocky-AppStream-${os_version}
 
-  versions="$(curl -fsSL https://dl.rockylinux.org/pub/rocky/)"
-  pattern='href="'"${os_version}"'/"'
-
-  if [[ ${versions,,} = *${pattern}* ]]; then
-    base_url="https://dl.rockylinux.org/pub/rocky/${os_version}"
-  else
+  # test direct url, otherwise use vault
+  base_url="https://dl.rockylinux.org/pub/rocky/${os_version}"
+  if ! curl --output /dev/null --silent --head --fail "${base_url}/BaseOS/"; then
     base_url="https://dl.rockylinux.org/vault/rocky/${os_version}"
   fi
 


### PR DESCRIPTION
`10_sideload_rocky` rather than parsing available versions, directly check if the direct url if valid, otherwise use vault