### PR TITLE
Remove CentOS7 support

### DIFF
--- a/10_load_cuda_env
+++ b/10_load_cuda_env
@@ -8,7 +8,7 @@ for file in /usr/local/share/just/info/cuda/*_common; do
   source "${file}"
 done
 
-if command -v yum 2>&1 > /dev/null; then
+if command -v dnf 2>&1 > /dev/null; then
   for file in /usr/local/share/just/info/cuda/*_rhel; do
     source "${file}"
   done

--- a/30_install_cuda
+++ b/30_install_cuda
@@ -74,7 +74,7 @@ function install_cuda_repo_and_packages()
   cuda_version=(${CUDA_VERSION})
   IFS="${OLD_IFS}"
 
-  if command -v yum 2>&1 > /dev/null; then
+  if command -v dnf 2>&1 > /dev/null; then
     source /etc/os-release
     rhel_major_version=${VERSION_ID%%.*}
 
@@ -157,10 +157,7 @@ function install_cuda_repo_and_packages()
     # Install #
     ###########
 
-    if [ "${rhel_major_version}" = "7" ]; then
-      ulimit -n 1048576 # https://github.com/containerd/containerd/discussions/6780
-    fi
-    yum install --setopt=obsoletes=0 -y "${packages[@]}"
+    dnf install --setopt=obsoletes=0 -y "${packages[@]}"
     rm -rf /var/cache/yum/*
   elif command -v apt-get 2>&1 > /dev/null; then
     source /etc/os-release

--- a/40_install_cudagl
+++ b/40_install_cudagl
@@ -24,7 +24,7 @@ function install_cudagl_packages()
       ;;
   esac
 
-  if command -v yum 2>&1 > /dev/null; then
+  if command -v dnf 2>&1 > /dev/null; then
     source /etc/os-release
     rhel_major_version=${VERSION_ID%%.*}
 
@@ -79,10 +79,7 @@ function install_cudagl_packages()
     ###########
 
     if [ "${#packages[@]}" -ne "0" ]; then
-      if [ "${rhel_major_version}" = "7" ]; then
-        ulimit -n 1048576 # https://github.com/containerd/containerd/discussions/6780
-      fi
-      yum install --setopt=obsoletes=0 -y "${packages[@]}"
+      dnf install --setopt=obsoletes=0 -y "${packages[@]}"
       rm -rf /var/cache/yum/*
     fi
 

--- a/recipe_cuda.Dockerfile
+++ b/recipe_cuda.Dockerfile
@@ -58,7 +58,7 @@ ONBUILD RUN set -o pipefail; \
             }; \
             # Env Vars
             # Currently all the fedoras use the same vars, so the first file found is good enough
-            for rhel in ubi10 ubi9 ubi8 ubi7 rockylinux10 rockylinux9 rockylinux8 centos7; do \
+            for rhel in ubi10 ubi9 ubi8 rockylinux10 rockylinux9 rockylinux8; do \
               if [ -d "/cuda/dist/${CUDA_VERSION}/${rhel}" ]; then \
                 parse_os "/cuda/dist/${CUDA_VERSION}/${rhel}" rhel; \
                 break; \

--- a/recipe_cudagl.Dockerfile
+++ b/recipe_cudagl.Dockerfile
@@ -21,24 +21,6 @@ make -j"$(nproc)" install-strip
 find /usr/local/lib -type f -name 'lib*.la' -delete
 EOF
 
-FROM centos:7 as centos7
-
-SHELL ["/usr/bin/env", "bash", "-euxvc"]
-
-RUN if [ "$(ulimit -n)" -gt "1048576" ]; then \
-      # https://github.com/containerd/containerd/discussions/6780
-      ulimit -n 1048576; \
-    fi; \
-    yum install -y install git make libtool gcc pkgconfig python2 libXext-devel \
-                   libX11-devel xorg-x11-proto-devel \
-                   glibc-devel.x86_64 libgcc.x86_64 libXext-devel.x86_64 libX11-devel.x86_64 \
-                   glibc-devel.i686 libgcc.i686 libXext-devel.i686 libX11-devel.i686; \
-    rm -rf /var/cache/yum/*
-
-ARG LIBGLVND_VERSION=v1.2.0
-COPY --from=scripts /setup /setup
-RUN /setup
-
 FROM redhat/ubi8 as ubi8
 
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
@@ -46,7 +28,7 @@ SHELL ["/usr/bin/env", "bash", "-euxvc"]
 ADD --chmod=755 10_sideload_rocky /usr/local/share/just/scripts/
 
 RUN /usr/local/share/just/scripts/10_sideload_rocky; \
-    yum install -y --enablerepo=rocky-appstream,rocky-powertools \
+    dnf install -y --enablerepo=rocky-appstream,rocky-powertools \
                    git make libtool gcc pkgconfig python2 libXext-devel \
                    libX11-devel xorg-x11-proto-devel\
                    glibc-devel.i686 libgcc.i686 libXext-devel.i686 libX11-devel.i686; \
@@ -63,7 +45,7 @@ RUN /setup
 # ADD 10_sideload_rocky /
 
 # RUN bash /10_sideload_rocky; \
-#     yum install -y --enablerepo=rocky-appstream,rocky-crb \
+#     dnf install -y --enablerepo=rocky-appstream,rocky-crb \
 #                    git make libtool gcc pkgconfig libXext-devel \
 #                    libX11-devel xorg-x11-proto-devel\
 #                    glibc-devel.i686 libgcc.i686 libXext-devel.i686 libX11-devel.i686; \
@@ -77,8 +59,6 @@ FROM alpine:3.11.8
 
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
-COPY --from=centos7 /usr/local/lib  /usr/local/share/just/info/rhel7/lib
-COPY --from=centos7 /usr/local/lib64  /usr/local/share/just/info/rhel7/lib64
 COPY --from=ubi8 /usr/local/lib /usr/local/share/just/info/rhel8/lib
 COPY --from=ubi8 /usr/local/lib64 /usr/local/share/just/info/rhel8/lib64
 # COPY --from=ubi9 /usr/local/lib /usr/local/share/just/info/rhel8/lib


### PR DESCRIPTION
Centos7 in cuda gl was failing due to EOL

I also replaced `yum` calls with `dnf`, since we no longer need to use the backwards compatible call. This will hopefully cause centos7 to fail earlier on, so users can know they need to update earlier on.