### PR TITLE
Fix cuda ref not being configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -343,7 +343,7 @@ CUDA
 
 ============================ ============
 Name                         CUDA
-Build Args                   ``CUDA_REPO_REF`` - The ref of the CUDA container repo parsed
+Special Args                 ``CUDA_REPO_REF`` - The ref of the CUDA container repo parsed. Set via exporting the environment variable ``DOCKER_RECIPE_CUDA_REPO_REF``. Default: ``81682547e12c8807ebc5fa61ff4576510925a324``
 Build Args                   ``CUDA_VERSION`` - Version of CUDA to install (e.g. ``10.2`` or ``11.0.7``)
 Build Args                   ``CUDNN_VERSION`` - Optional: Version of CUDNN to install. (e.g. ``7`` or ``8``)
 Build Args                   ``CUDA_RECIPE_TARGET`` - Optional: Specifies how much of the CUDA stack to install (explained below). Default: ``runtime``

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
     build:
       context: .
       dockerfile: recipe_cudagl.Dockerfile
-      args:
-        LIBGLVND_VERSION: "${DOCKER_RECIPE_LIBGLVND_VERSION-v1.2.0}"
+      # args:
+      #   LIBGLVND_VERSION: "${LIBGLVND_VERSION}"
       #   CUDA_RECIPE_TARGET: "${CUDA_RECIPE_TARGET}"
     image: ${VSI_RECIPE_REPO-vsiri/recipe}:cudagl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,8 @@ services:
     build:
       context: .
       dockerfile: recipe_cuda.Dockerfile
-      # args:
+      args:
+        CUDA_REPO_REF: "${DOCKER_RECIPE_CUDA_REPO_REF-81682547e12c8807ebc5fa61ff4576510925a324}"
       #   CUDA_VERSION: "${CUDA_VERSION}"
       #   CUDNN_VERSION: "${CUDNN_VERSION}"
       #   CUDA_RECIPE_TARGET: "${CUDA_RECIPE_TARGET}"
@@ -141,7 +142,7 @@ services:
     build:
       context: .
       dockerfile: recipe_cudagl.Dockerfile
-      # args:
-      #   LIBGLVND_VERSION: "${LIBGLVND_VERSION}"
+      args:
+        LIBGLVND_VERSION: "${DOCKER_RECIPE_LIBGLVND_VERSION-v1.2.0}"
       #   CUDA_RECIPE_TARGET: "${CUDA_RECIPE_TARGET}"
     image: ${VSI_RECIPE_REPO-vsiri/recipe}:cudagl

--- a/recipe_cuda.Dockerfile
+++ b/recipe_cuda.Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/usr/bin/env", "bash", "-euxvc"]
 # This ADD can be commented out to skip the test
 # ADD https://gitlab.com/api/v4/projects/2330984/repository/branches/master /cuda-main.json
 
-ARG CUDA_REPO_REF=81682547e12c8807ebc5fa61ff4576510925a324
+ARG CUDA_REPO_REF
 RUN if [ -f "/cuda-main.json" ]; then \
       new_main_ref="$(sed 's|.*"id":"\([^"]*\).*|\1|' /cuda-main.json)"; \
       rm /cuda-main.json; \

--- a/recipe_cudagl.Dockerfile
+++ b/recipe_cudagl.Dockerfile
@@ -34,7 +34,7 @@ RUN /usr/local/share/just/scripts/10_sideload_rocky; \
                    glibc-devel.i686 libgcc.i686 libXext-devel.i686 libX11-devel.i686; \
     rm -rf /var/cache/yum/*
 
-ARG LIBGLVND_VERSION=v1.2.0
+ARG LIBGLVND_VERSION
 COPY --from=scripts /setup /setup
 RUN /setup
 

--- a/recipe_cudagl.Dockerfile
+++ b/recipe_cudagl.Dockerfile
@@ -34,7 +34,7 @@ RUN /usr/local/share/just/scripts/10_sideload_rocky; \
                    glibc-devel.i686 libgcc.i686 libXext-devel.i686 libX11-devel.i686; \
     rm -rf /var/cache/yum/*
 
-ARG LIBGLVND_VERSION
+ARG LIBGLVND_VERSION=v1.2.0
 COPY --from=scripts /setup /setup
 RUN /setup
 


### PR DESCRIPTION
Now `CUDA_REPO_REF` can be set by a parent project.