### PR TITLE
cudagl for UBI 9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -423,7 +423,7 @@ CUDA GL
 ============================ ============
 Name                         CUDA GL
 Build Args                   ``CUDA_RECIPE_TARGET`` - Specifies how much of the CUDA stack to install (explained further above in the CUDA recipe). Default: ``runtime``
-Build Args                   ``LIBGLVND_VERSION`` - The version of the GLVND used. Default: ``v1.2.0``
+Build Args                   ``LIBGLVND_VERSION`` - The version of the GLVND used. Default: ``v1.7.0``
 Environment Variable         ``NVIDIA_DRIVER_CAPABILITIES`` - For OpenGL offscreen rendering, you at least need `graphics,compute,utility`
 Output dir                   ``/usr/local``
 Minimum Dockerfile frontend: docker/dockerfile:1.3-labs or docker/dockerfile:1.4

--- a/recipe_cudagl.Dockerfile
+++ b/recipe_cudagl.Dockerfile
@@ -34,7 +34,7 @@ RUN /usr/local/share/just/scripts/10_sideload_rocky; \
                    glibc-devel.i686 libgcc.i686 libXext-devel.i686 libX11-devel.i686; \
     rm -rf /var/cache/yum/*
 
-ARG LIBGLVND_VERSION=v1.2.0
+ARG LIBGLVND_VERSION=v1.7.0
 COPY --from=scripts /setup /setup
 RUN /setup
 
@@ -51,7 +51,7 @@ RUN /usr/local/share/just/scripts/10_sideload_rocky; \
                    glibc-devel.i686 libgcc.i686 libXext-devel.i686 libX11-devel.i686; \
     rm -rf /var/cache/yum/*
 
-ARG LIBGLVND_VERSION=v1.2.0
+ARG LIBGLVND_VERSION=v1.7.0
 COPY --from=scripts /setup /setup
 RUN /setup
 
@@ -107,7 +107,7 @@ ONBUILD RUN case "${CUDA_RECIPE_TARGET}" in *devel*) \
               ;; \
             esac
 
-ONBUILD ARG LIBGLVND_VERSION=v1.2.0
+ONBUILD ARG LIBGLVND_VERSION=v1.7.0
 
 ONBUILD COPY <<EOF /usr/local/share/just/info/cuda/00_cudagl_common
 : \${CUDA_RECIPE_TARGET:=${CUDA_RECIPE_TARGET}}

--- a/recipe_cudagl.Dockerfile
+++ b/recipe_cudagl.Dockerfile
@@ -38,22 +38,22 @@ ARG LIBGLVND_VERSION=v1.2.0
 COPY --from=scripts /setup /setup
 RUN /setup
 
-# Does not currently work. Doesn't find GLDouble, and I don't know why nor care yet
-# FROM redhat/ubi9 as ubi9
+FROM redhat/ubi9 as ubi9
 
-# SHELL ["/usr/bin/env", "bash", "-euxvc"]
-# ADD 10_sideload_rocky /
+SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
-# RUN bash /10_sideload_rocky; \
-#     dnf install -y --enablerepo=rocky-appstream,rocky-crb \
-#                    git make libtool gcc pkgconfig libXext-devel \
-#                    libX11-devel xorg-x11-proto-devel\
-#                    glibc-devel.i686 libgcc.i686 libXext-devel.i686 libX11-devel.i686; \
-#     rm -rf /var/cache/yum/*
+ADD --chmod=755 10_sideload_rocky /usr/local/share/just/scripts/
 
-# ARG LIBGLVND_VERSION=v1.2.0
-# COPY --from=scripts /setup /setup
-# RUN /setup
+RUN /usr/local/share/just/scripts/10_sideload_rocky; \
+    dnf install -y --enablerepo=rocky-appstream,rocky-crb \
+                   git make libtool gcc pkgconfig libXext-devel \
+                   libX11-devel xorg-x11-proto-devel\
+                   glibc-devel.i686 libgcc.i686 libXext-devel.i686 libX11-devel.i686; \
+    rm -rf /var/cache/yum/*
+
+ARG LIBGLVND_VERSION=v1.2.0
+COPY --from=scripts /setup /setup
+RUN /setup
 
 FROM alpine:3.11.8
 
@@ -61,8 +61,9 @@ SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 COPY --from=ubi8 /usr/local/lib /usr/local/share/just/info/rhel8/lib
 COPY --from=ubi8 /usr/local/lib64 /usr/local/share/just/info/rhel8/lib64
-# COPY --from=ubi9 /usr/local/lib /usr/local/share/just/info/rhel8/lib
-# COPY --from=ubi9 /usr/local/lib64 /usr/local/share/just/info/rhel8/lib64
+
+COPY --from=ubi9 /usr/local/lib /usr/local/share/just/info/rhel9/lib
+COPY --from=ubi9 /usr/local/lib64 /usr/local/share/just/info/rhel9/lib64
 
 ADD --chmod=644 10_load_cuda_env /usr/local/share/just/user_run_patch/
 ADD --chmod=755 30_ldconfig 40_install_cudagl /usr/local/share/just/container_build_patch/


### PR DESCRIPTION
Update cudagl recipe for UBI 9.  

Successful build by updating libglvnd default to `LIBGLVND_VERSION=1.7.0` released in Sept 2023.