### PR TITLE
conda-python bookworm

### DIFF
--- a/recipe_conda_python.Dockerfile
+++ b/recipe_conda_python.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-20210311-slim
+FROM debian:bookworm-20250630-slim
 
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
 


### PR DESCRIPTION
`conda-python` change debian base image from EOL buster to bookworm