### PR TITLE
pip-tools pip-opencv

### DIFF
--- a/pip-opencv
+++ b/pip-opencv
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+if [[ ${-} != *i* ]]; then
+  source_once &> /dev/null && return 0
+fi
+
+#*# docker/recipes/pip-opencv
+
+#**
+# ==========
+# pip opencv
+# ==========
+#
+# .. default-domain:: bash
+#
+# .. file:: pip-opencv
+#
+# This script allow us to install only one of the four available opencv-python packages via pip-tools.
+#
+# OpenCV provides four interchangable python packages:
+# - opencv-contrib-python: main modules, contrib/extra, GUI
+# - opencv-python: main modules, GUI
+# - opencv-contrib-python-headless: main modules, contrib/extra, headless (no GUI)
+# - opencv-python-headless: main modules, headless (no GUI)
+#
+# Users are advised to install only one of the four packages opencv-python depending on their needs
+# https://pypi.org/project/opencv-python/#:~:text=There%20are%20four,only%20one%20package
+#
+# This function will modify a pip-tools ``requirements.txt`` file to keep only the most fully featured opencv-python package.  Less featured opencv-python packages are commented out from the ``requirements.txt`` file.
+#
+# A subsequent ``pip-sync`` must be run with the argument ``--pip-args '--no-deps'`` to ensure only one opencv-python package is installed.
+#
+# :Arguments: * ``$1``... - ``requirements.txt`` file to be modified
+#
+# .. function:: pip-opencv
+#
+# Same syntax as :file:`pip-opencv`
+#**
+function pip-opencv()
+{
+  # requirements.txt file to be modified
+  local file="${1}"
+
+  # check for multiple opencv-python packages
+  local num_opencv=$(grep -c '^opencv.*-python.*==' "${file}" || :)
+  if (( ${num_opencv} <= 1 )); then
+    return 0
+  fi
+
+  # check for contrib & GUI options
+  local num_gui=$(grep -c -e '^opencv-contrib-python==' -e '^opencv-python==' "${file}" || :)
+  local gui=$(( ${num_gui} > 0 ))
+
+  local num_contrib=$(grep -c '^opencv-contrib-python.*==' "${file}" || :)
+  local contrib=$(( ${num_contrib} > 0 ))
+
+  # package to keep
+  local selected=
+  if [ "${gui}" == "1" ] && [ "${contrib}" == "1" ]; then
+    selected="opencv-contrib-python"
+  elif [ "${gui}" == "1" ] && [ "${contrib}" == "0" ]; then
+    selected="opencv-python"
+  elif [ "${gui}" == "0" ] && [ "${contrib}" == "1" ]; then
+    selected="opencv-contrib-python-headless"
+  else
+    selected="opencv-python-headless"
+  fi
+
+  # report
+  echo "Keeping only ${selected} (commenting out other opencv-python packages)" >&2
+
+  # keep only the first instance of the selected package
+  local packages=(
+      opencv-contrib-python
+      opencv-python
+      opencv-contrib-python-headless
+      opencv-python-headless
+  )
+
+  for package in "${packages[@]}"; do
+    local pattern="/^${package}==/s/^/# /g"
+    if [ "${package}" == "${selected}" ]; then
+      # replace all but the first occurance
+      pattern="0,/^${package}==/!{${pattern}}"
+    fi
+    sed "${pattern}" -i "${file}"
+  done
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
+  set -eu
+  pip-opencv "${@}"
+fi

--- a/pip-opencv
+++ b/pip-opencv
@@ -17,6 +17,8 @@ fi
 #
 # This script allow us to install only one of the four available opencv-python packages via pip-tools.
 #
+# :Arguments: * ``$1``... - The path to the ``requirements.txt`` to be inline patched
+#
 # OpenCV provides four interchangable python packages:
 # - opencv-contrib-python: main modules, contrib/extra, GUI
 # - opencv-python: main modules, GUI

--- a/pip-opencv
+++ b/pip-opencv
@@ -28,7 +28,7 @@ fi
 #
 # This function will modify a pip-tools ``requirements.txt`` file to keep only the most fully featured opencv-python package.  Less featured opencv-python packages are commented out from the ``requirements.txt`` file.
 #
-# A subsequent ``pip-sync`` must be run with the argument ``--pip-args '--no-deps'`` to ensure only one opencv-python package is installed.
+# A subsequent ``pip-sync`` must be run with the argument ``--pip-args --no-deps`` to ensure only one opencv-python package is installed.
 #
 # :Arguments: * ``$1``... - ``requirements.txt`` file to be modified
 #

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -10,6 +10,13 @@ services:
         PIPENV_VIRTUALENV: "/foo"
         PIPENV_PYTHON: "/bar"
     image: vsiri/test_recipe:test_pipenv
+  test_pip-tools:
+    build:
+      context: .
+      dockerfile: test_pip-tools.Dockerfile
+      args:
+        PIP_TOOLS_VERSION: "7.5.0"
+    image: vsiri/test_recipe:test_pip-tools
   test_git-lfs:
     build:
       context: .

--- a/tests/test-pip-tools.bsh
+++ b/tests/test-pip-tools.bsh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+if [ -z "${VSI_COMMON_DIR+set}" ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.."; pwd)"
+fi
+
+source "${VSI_COMMON_DIR}/tests/testlib.bsh"
+source "${TESTLIB_DIR}/test_utils.bsh"
+
+: ${DOCKER=docker}
+
+# array to newline-delimited requirements
+function array_to_req()
+{
+  printf '%s\n' "${@}"
+}
+
+# test pip-opencv (container not required)
+begin_test "pip-opencv"
+(
+  setup_test
+
+  # load function
+  source "${VSI_COMMON_DIR}/docker/recipes/pip-opencv"
+
+  # single pip-opencv test
+  function _test-pip-opencv()
+  {
+    # inputs, replacing spaces with newlines
+    local input="${1}"
+    local expected="${2:-${input}}"
+
+    # save input to temporary file
+    local file="$(mktemp -p "${TESTDIR}")"
+    echo -e "${input}" >> "${file}"
+
+    # run pip-opencv and check result
+    pip-opencv "${file}"
+    assert_str_eq "$(cat "${file}")" "${expected}"
+  }
+
+  # no opencv-python
+  REQ_A=(
+    "a==1.2.3"
+    "b==2.3.4"
+  )
+  _test-pip-opencv "$(array_to_req "${REQ_A[@]}")"
+
+  # single version
+  REQ_B=(
+    "${REQ_A[@]}"
+    "opencv-python==4.10"
+  )
+  _test-pip-opencv "$(array_to_req "${REQ_B[@]}")"
+
+  # two versions, including duplicates
+  REQ_C=(
+    "${REQ_A[@]}"
+    "opencv-python-headless==4.10"
+    "opencv-python==4.11"
+    "opencv-python-headless==4.12"
+    "opencv-python==4.13"
+  )
+  EXP_C=(
+    "${REQ_A[@]}"
+    "# opencv-python-headless==4.10"
+    "opencv-python==4.11"
+    "# opencv-python-headless==4.12"
+    "# opencv-python==4.13"
+  )
+  _test-pip-opencv "$(array_to_req "${REQ_C[@]}")" \
+                   "$(array_to_req "${EXP_C[@]}")"
+
+  # all versions including duplicates
+  REQ_D=(
+    "${REQ_A[@]}"
+    "opencv-python-headless==4.10"
+    "opencv-contrib-python-headless==4.11"
+    "opencv-python==4.12"
+    "opencv-contrib-python==4.13"
+    "opencv-contrib-python-headless==4.14"
+    "opencv-contrib-python==4.15"
+  )
+  EXP_D=(
+    "${REQ_A[@]}"
+    "# opencv-python-headless==4.10"
+    "# opencv-contrib-python-headless==4.11"
+    "# opencv-python==4.12"
+    "opencv-contrib-python==4.13"
+    "# opencv-contrib-python-headless==4.14"
+    "# opencv-contrib-python==4.15"
+  )
+  _test-pip-opencv "$(array_to_req "${REQ_D[@]}")" \
+                   "$(array_to_req "${EXP_D[@]}")"
+
+)
+end_test
+
+# test pip-opencv within a docker
+if ! command -v "${DOCKER}" &> /dev/null; then
+  skip_next_test
+fi
+begin_test "pip-opencv docker"
+(
+  setup_test
+
+  # run pip-sync & get list of installed packages
+  # - optionally run ``pip-opencv`` to resolve opencv-python dependencies
+  # - use ``pip-sync --pip-args "--no-deps" ...`` to ensure only selected packages are installed
+  function pip-sync-docker()
+  {
+    docker run --rm vsiri/test_recipe:test_pip-tools bash -c '
+        file=/tmp/requirements.txt
+        echo "${1}" > "${file}"
+        if [ "${2:-false}" == "true" ]; then pip-opencv ${file} >&2; fi
+        pip-sync -v --pip-args "--no-deps" ${file} >&2
+        pip freeze
+      ' -- "${@}"
+  }
+
+  # requirements
+  REQ_ARRAY=(
+    "numpy==2.2.6"
+    "opencv-python==4.12.0.88"
+    "opencv-python-headless==4.12.0.88"
+  )
+  REQ="$(array_to_req "${REQ_ARRAY[@]}")"
+
+  # test full sync, where two opencv packages are installed
+  RESULT="$(pip-sync-docker "${REQ}")"
+  assert_sub_str "${RESULT}" "pip-tools==7.5.0"
+  assert_sub_str "${RESULT}" "numpy==2.2.6"
+  assert_sub_str "${RESULT}" "opencv-python==4.12.0.88"
+  assert_sub_str "${RESULT}" "opencv-python-headless==4.12.0.88"
+
+  # test sync with pip-opencv, installing only one opencv package
+  RESULT="$(pip-sync-docker "${REQ}" true)"
+  assert_sub_str "${RESULT}" "pip-tools==7.5.0"
+  assert_sub_str "${RESULT}" "numpy==2.2.6"
+  assert_sub_str "${RESULT}" "opencv-python==4.12.0.88"
+  not assert_sub_str "${RESULT}" "opencv-python-headless==4.12.0.88"
+
+)
+end_test

--- a/tests/test_pip-tools.Dockerfile
+++ b/tests/test_pip-tools.Dockerfile
@@ -1,0 +1,11 @@
+FROM vsiri/recipe:pip-tools AS pip-tools
+
+FROM python:3.11
+SHELL ["/usr/bin/env", "bash", "-euxvc"]
+
+ARG PIP_TOOLS_VERSION=
+RUN pip3 install pip-tools${PIP_TOOLS_VERSION:+"==${PIP_TOOLS_VERSION}"}
+
+COPY --from=pip-tools /usr/local /usr/local
+RUN ln -s "$(which python3)" /bar; \
+    shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done


### PR DESCRIPTION
Add the new script `pip-opencv` to the pip-tools recipe to select a single opencv-python dependency.

OpenCV provides four interchangable python packages:
- `opencv-contrib-python`: main modules, contrib/extra, GUI
- `opencv-python`: main modules, GUI
- `opencv-contrib-python-headless`: main modules, contrib/extra, headless (no GUI)
- `opencv-python-headless`: main modules, headless (no GUI)

Users are advised to install only one of the four packages opencv-python depending on their needs.
https://pypi.org/project/opencv-python/#:~:text=There%20are%20four,only%20one%20package

`pip-opencv` will modify a pip-tools `requirements.txt` file to keep only the most fully featured opencv python package.  Less featured opencv-python packages are commented out from the `requirements.txt` file.

A subsequent `pip-sync` run with the argument `--pip-args '--no-deps'` will ensure only one opencv-python package is installed.  The `--no-deps` should not be a problem, as a `requirements.txt` file generated from `pip-compile` is expected to list all necessary dependencies already.

Unit tests check that `pip-opencv` comments out expected files from demonstrative `requirements.txt` files, and checks that `pip-sync --pip-args '--no-deps'` will actually install only one opencv python package.