### PR TITLE
CircleCI buildx

### DIFF
--- a/.circleci/buildkitd.toml
+++ b/.circleci/buildkitd.toml
@@ -1,0 +1,3 @@
+[registry."localhost:5000"]
+http = true
+insecure = true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,68 +26,190 @@ commands:
             cd "${VSI_COMMON_DIR}/docker/recipes"
             git checkout "${CIRCLE_SHA1}"
 
-  # run "ci_load" command on user-selected docker compose file
-  # - cache is updated only from main branch of main repo (not forks)
-  # - assumes python3 with pyyaml is already available
-  # - assumes docker login was successful
-  # - required environment variables:
-  #     $VSI_COMMON_DIR - location of vsi_common repo
-  # - optional environment variables
-  #     $CI_RECIPE_REPO - dockerhub repo for recipe cache (default "vsiri/ci_cache_recipes")
-  #     $CI_RECIPE_VERSION - version string for recipe cache (default "")
-  #     $JUST_CI_BRANCH_PUSH - branch (besides main) for dockerhub push
-  # - each service identified in the docker compose file will be separately
-  #   built via "${VSI_COMMON_DIR}/linux/ci_load.py"
-  # - As we are building recipes themselves, we ignore the vsiri/recipe
-  #   dockerhub repo by setting "--recipe-repo" to a dummy variable.
-  ci_load:
-    description: Build dockers (ci_load)
+  # docker setup
+  # - setup a remote docker environment
+  # - dockerhub login using project variables
+  # - create a buildx builder using the "docker-container" driver to
+  #   take advantage of "cache-to" capabilities.
+  # - use of the docker-container driver also requires a local registry when
+  #   building test images to be able to source the latest recipe images
+  #   (docker-container only uses registry images during the build process)
+  setup_docker:
+    description: Setup docker
+    steps:
+
+      - setup_remote_docker
+
+      - run:
+          name: Dockerhub login
+          command: echo "${DOCKER_PASS}" | docker login -u "${DOCKER_USER}" --password-stdin
+
+      - run:
+          name: Buildx with "docker-container" driver
+          command: |
+            : ${CONTEXT_NAME="ci_builder_context"}
+            : ${BUILDER_NAME="ci_builder"}
+            : ${BUILDKITD_TOML="${RECIPE_DIR}/.circleci/buildkitd.toml"}
+            docker context create "${CONTEXT_NAME}"
+            docker buildx create \
+                --name "${BUILDER_NAME}" \
+                --driver docker-container \
+                --driver-opt network=host \
+                --config "${BUILDKITD_TOML}" \
+                ${CONTEXT_NAME}
+            docker buildx use --builder "${BUILDER_NAME}"
+
+      - run:
+          name: Start localhost docker registry
+          command: |
+            : ${COMPOSE_FILE="${RECIPE_DIR}/.circleci/docker-compose.yml"}
+            docker compose -f "${COMPOSE_FILE}" up -d
+
+  # run "docker buildx bake" on user-selected docker compose file
+  build:
+    description: Build dockers (buildx)
     parameters:
       step_name:
         description: Step name
         type: string
-        default: Build recipes (ci_load)
-      compose_file:
-        description: docker compose file
-        type: string
+        default: Build recipes (buildx)
+      step_type:
+        description: Build recipe or test
+        type: enum
+        enum: ["recipe", "test"]
     steps:
       - run:
           name: << parameters.step_name >>
           command: |
 
-            set -x
-
-            # push from main repo, main or ${JUST_CI_BRANCH_PUSH} branches
+            # some push/cache to dockerhub options are enabled only from:
+            # - `main` branch of VSI repo
+            # - `${CI_BRANCH_PUSH}` branch of VSI repo
             if [[ "${CIRCLE_PROJECT_USERNAME,,}" == "visionsystemsinc" && \
                   ("${CIRCLE_BRANCH}" == "main" || \
-                   "${CIRCLE_BRANCH}" == "${JUST_CI_BRANCH_PUSH-}") ]]
+                   "${CIRCLE_BRANCH}" == "${CI_BRANCH_PUSH-}") ]]
             then
-              CI_PUSH_OPT="--push"
+              PUSH=1
             else
-              CI_PUSH_OPT="--no-push"
+              PUSH=0
             fi
 
-            # environment
-            : ${CI_RECIPE_REPO="vsiri/ci_cache_recipes"}
-            : ${CI_RECIPE_VERSION=}
-            COMPOSE_FILE="<< parameters.compose_file >>"
+            # options based on "step_type" parameter
+            STEP_TYPE="<< parameters.step_type >>"
+
+            if [ "${STEP_TYPE}" == "recipe" ]; then
+              COMPOSE_FILE="${RECIPE_DIR}/docker-compose.yml"
+              LOCALHOST_PUSH=1  # push to localhost registry needed for tests
+              DOCKERHUB_PUSH="${PUSH}"  # push to dockerhub in some cases
+              DOCKERHUB_CACHE_TO="${PUSH}"  # cache-to dockerhub in some cases
+
+            elif [ "${STEP_TYPE}" == "test" ]; then
+              COMPOSE_FILE="${RECIPE_DIR}/tests/docker-compose.yml"
+              LOCALHOST_PUSH=0  # push to localhost registry not needed
+              DOCKERHUB_PUSH=0  # push to dockerhub not needed
+              DOCKERHUB_CACHE_TO="${PUSH}"  # cache-to dockerhub in some cases
+
+            else
+              echo "Unrecognized step type '${STEP_TYPE}'" >&2
+              exit 1
+            fi
+
+            # report options
+            echo "--------------------"
+            echo "COMPOSE_FILE=${COMPOSE_FILE}"
+            echo "LOCALHOST_PUSH=${LOCALHOST_PUSH}"
+            echo "DOCKERHUB_PUSH=${DOCKERHUB_PUSH}"
+            echo "DOCKERHUB_CACHE_TO=${DOCKERHUB_CACHE_TO}"
+            echo "--------------------"
+
+            # discover services
             SERVICES=( $(docker compose -f "${COMPOSE_FILE}" config --services) ) # noquotes
 
-            # ci_load for each service
+            # function to discover service image from docker-compose file
+            function get_image() {
+              docker compose -f "${COMPOSE_FILE}" config --images "${1}"
+            }
+
+            # localhost registry
+            LOCALHOST_RECIPE_REPO="localhost:5000/recipe"
+            LOCALHOST_TEST_REPO="${LOCALHOST_RECIPE_REPO}-test"
+
+            # dockerhub registry
+            DOCKERHUB_RECIPE_REPO="vsiri/recipe"
+            DOCKERHUB_TEST_REPO="${DOCKERHUB_RECIPE_REPO}-test"
+
+            # dockerhub cache
+            DOCKERHUB_CACHE_REPO="${DOCKERHUB_RECIPE_REPO}-cache"
+
+            # build options
+            OPTS=(
+              -f "${COMPOSE_FILE}"
+              --load
+              # --progress=plain
+
+              # direct the buildx 'docker-continer' driver to source recipes
+              # from the localhost registry (not dockerhub)
+              "--set=*.args.VSI_RECIPE_REPO=${LOCALHOST_RECIPE_REPO}"
+            )
+
+            # array of docker images to push after build
+            IMAGES_TO_PUSH=()
+
+            # cache options
             for SERVICE in "${SERVICES[@]}"; do
-              if [[ "${SERVICE}" == *cudagl* ]]; then
-                continue
-              elif [[ "${SERVICE}" == *cuda* ]]; then
-                CI_PUSH_OPT="--no-push"
+
+              # default image tag (never pushed)
+              DEFAULT_TAG="$(get_image "${SERVICE}")"
+              OPTS+=( "--set=${SERVICE}.tags=${DEFAULT_TAG}" )
+
+              # optionally tag & push to localhost
+              if [ "${LOCALHOST_PUSH-}" == "1" ]; then
+                LOCALHOST_TAG="$(VSI_RECIPE_REPO="${LOCALHOST_RECIPE_REPO}" \
+                                 VSI_TEST_RECIPE_REPO="${LOCALHOST_TEST_REPO}" \
+                                 get_image "${SERVICE}")"
+                OPTS+=( "--set=${SERVICE}.tags=${LOCALHOST_TAG}" )
+                IMAGES_TO_PUSH+=( "${LOCALHOST_TAG}" )
               fi
-              python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
-                --recipe-repo "IGNORE" \
-                ${CI_RECIPE_REPO:+ --cache-repo "${CI_RECIPE_REPO}"} \
-                ${CI_RECIPE_VERSION:+ --cache-version "${CI_RECIPE_VERSION}"} \
-                --quiet-pull \
-                ${CI_PUSH_OPT} \
-                "${COMPOSE_FILE}" "${SERVICE}"
+
+              # optionally tag & push to dockerhub
+              # (do not push cuda & cudagl images)
+              if [ "${DOCKERHUB_PUSH-}" == "1" ] && [[ "${SERVICE}" != *cuda* ]]; then
+                DOCKERHUB_TAG="$(VSI_RECIPE_REPO="${DOCKERHUB_RECIPE_REPO}" \
+                                 VSI_TEST_RECIPE_REPO="${DOCKERHUB_TEST_REPO}" \
+                                 get_image "${SERVICE}")"
+                OPTS+=( "--set=${SERVICE}.tags=${DOCKERHUB_TAG}" )
+                IMAGES_TO_PUSH+=( "${DOCKERHUB_TAG}" )
+              fi
+
+              # service dockerhub cache
+              CACHE="${DOCKERHUB_CACHE_REPO}:${SERVICE}"
+
+              # always cache-from
+              OPTS+=( "--set=${SERVICE}.cache-from=ref=${CACHE},type=registry" )
+
+              # optionally cache-to
+              if [ "${DOCKERHUB_CACHE_TO-}" == "1" ]; then
+                OPTS+=( "--set=${SERVICE}.cache-to=ref=${CACHE},type=registry,mode=max,image-manifest=true" )
+              fi
+
             done
+
+            # report & build
+            pushd "$(dirname "${COMPOSE_FILE}")" &> /dev/null
+              docker buildx bake --print ${OPTS[@]} ${SERVICES[@]}
+              docker buildx bake ${OPTS[@]} ${SERVICES[@]}
+            popd &> /dev/null
+
+            # report local images
+            echo -e "\n----- DOCKER IMAGES -----"
+            docker images
+
+            # push images
+            for IMAGE in "${IMAGES_TO_PUSH[@]}"; do
+              echo -e "\n----- PUSH ${IMAGE} ------"
+              docker push "${IMAGE}"
+            done
+
 
 # -----
 # CircleCI jobs
@@ -97,7 +219,7 @@ jobs:
   # linux docker environment
   build_and_test:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.11
     shell: /bin/bash -eo pipefail
     working_directory: ~/vsi
     environment:
@@ -106,26 +228,16 @@ jobs:
 
     steps:
 
-      - run:
-          name: Install software
-          command: |
-            pip3 install pyyaml
-
       - checkout_in_vsi_common
-      - setup_remote_docker
+      - setup_docker
 
-      - run:
-          name: Additional setup
-          command: |
-            docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
+      - build:
+          step_name: Build recipes (buildx)
+          step_type: recipe
 
-      - ci_load:
-          step_name: Build recipes (ci_load)
-          compose_file: ${RECIPE_DIR}/docker-compose.yml
-
-      - ci_load:
-          step_name: Build tests (ci_load)
-          compose_file: ${RECIPE_DIR}/tests/docker-compose.yml
+      - build:
+          step_name: Build tests (buildx)
+          step_type: test
 
       - run:
           name: Run integration tests
@@ -171,4 +283,4 @@ workflows:
   recipes:
     jobs:
       - build_and_test
-      - windows_test
+      # - windows_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,4 +283,4 @@ workflows:
   recipes:
     jobs:
       - build_and_test
-      # - windows_test
+      - windows_test

--- a/.circleci/docker-compose.yml
+++ b/.circleci/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  registry:
+    image: registry:2
+    ports:
+      - "5000:5000"
+    # volumes:
+    #   - ./data:/var/lib/registry
+    restart: always

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,3 +1,7 @@
+x-args:
+  common: &common_args
+    VSI_RECIPE_REPO:
+
 services:
 
   test_pipenv:
@@ -5,41 +9,48 @@ services:
       context: .
       dockerfile: test_pipenv.Dockerfile
       args:
+        <<: *common_args
         PIPENV_VERSION: "2021.11.23"
         VIRTUALENV_VERSION: "20.13.3"
         PIPENV_VIRTUALENV: "/foo"
         PIPENV_PYTHON: "/bar"
-    image: vsiri/test_recipe:test_pipenv
+    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_pipenv
   test_pip-tools:
     build:
       context: .
       dockerfile: test_pip-tools.Dockerfile
       args:
+        <<: *common_args
         PIP_TOOLS_VERSION: "7.5.0"
-    image: vsiri/test_recipe:test_pip-tools
+    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_pip-tools
   test_git-lfs:
     build:
       context: .
       dockerfile: test_git-lfs.Dockerfile
       args:
+        <<: *common_args
         GIT_LFS_VERSION: "v3.2.0"
-    image: vsiri/test_recipe:test_git-lfs
+    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_git-lfs
   test_cmake:
     build:
       context: .
       dockerfile: test_cmake.Dockerfile
       args:
+        <<: *common_args
         CMAKE_VERSION: "3.16.1"
-    image: vsiri/test_recipe:test_cmake
+    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_cmake
   test_rocky:
     build:
       context: .
       dockerfile: test_rocky.Dockerfile
-    image: vsiri/test_recipe:test_rocky
+      args:
+        <<: *common_args
+    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_rocky
   test_cuda:
     build:
       context: .
       dockerfile: test_cuda.Dockerfile
       args:
+        <<: *common_args
         CUDA_VERSION: "12.6.3"
-    image: vsiri/test_recipe:test_cuda
+    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_cuda

--- a/tests/test_cmake.Dockerfile
+++ b/tests/test_cmake.Dockerfile
@@ -1,4 +1,6 @@
-FROM vsiri/recipe:cmake AS cmake
+ARG VSI_RECIPE_REPO=vsiri/recipe
+
+FROM ${VSI_RECIPE_REPO}:cmake AS cmake
 
 FROM alpine:3.16.2
 

--- a/tests/test_cuda.Dockerfile
+++ b/tests/test_cuda.Dockerfile
@@ -1,4 +1,6 @@
-FROM vsiri/recipe:cuda AS cuda
+ARG VSI_RECIPE_REPO=vsiri/recipe
+
+FROM ${VSI_RECIPE_REPO}:cuda AS cuda
 
 FROM redhat/ubi8
 

--- a/tests/test_git-lfs.Dockerfile
+++ b/tests/test_git-lfs.Dockerfile
@@ -1,4 +1,6 @@
-FROM vsiri/recipe:git-lfs AS git-lfs
+ARG VSI_RECIPE_REPO=vsiri/recipe
+
+FROM ${VSI_RECIPE_REPO}:git-lfs AS git-lfs
 
 FROM alpine:3.16.2
 

--- a/tests/test_pip-tools.Dockerfile
+++ b/tests/test_pip-tools.Dockerfile
@@ -1,4 +1,6 @@
-FROM vsiri/recipe:pip-tools AS pip-tools
+ARG VSI_RECIPE_REPO=vsiri/recipe
+
+FROM ${VSI_RECIPE_REPO}:pip-tools AS pip-tools
 
 FROM python:3.11
 SHELL ["/usr/bin/env", "bash", "-euxvc"]

--- a/tests/test_pipenv.Dockerfile
+++ b/tests/test_pipenv.Dockerfile
@@ -1,4 +1,6 @@
-FROM vsiri/recipe:pipenv AS pipenv
+ARG VSI_RECIPE_REPO=vsiri/recipe
+
+FROM ${VSI_RECIPE_REPO}:pipenv AS pipenv
 
 FROM python:3.8
 SHELL ["/usr/bin/env", "bash", "-euxvc"]

--- a/tests/test_rocky.Dockerfile
+++ b/tests/test_rocky.Dockerfile
@@ -1,4 +1,7 @@
-FROM vsiri/recipe:rocky as rocky
+ARG VSI_RECIPE_REPO=vsiri/recipe
+
+FROM ${VSI_RECIPE_REPO}:rocky as rocky
+
 FROM redhat/ubi8
 COPY --from=rocky /usr/local /usr/local
 RUN test -e /usr/local/share/just/container_build_patch/10_sideload_rocky


### PR DESCRIPTION
Migrate CircleCI from the `ci_load` system to `docker buildx bake` with a dockerhub based cache system.

`docker buildx bake` can use `cache-from` to pull a complete build cache from dockerhub to speed builds.  The cache is populated from the main branch using the `cache-to` option. Note that `cache-to` requires using the `docker-container` buildx driver.

Use of the `docker-container` driver while building test images further calls for recipe images to be available in a docker registry (local docker images are not used). To ensure use of recipe images from the current branch (which are not pushed to dockerhub), we deploy a localhost registry to store the recipe images.

