### PR TITLE
BUG: CUDA 12.8

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -46,11 +46,19 @@ services:
       args:
         <<: *common_args
     image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_rocky
-  test_cuda:
+  test_cuda-12-6-3:
     build:
       context: .
       dockerfile: test_cuda.Dockerfile
       args:
         <<: *common_args
         CUDA_VERSION: "12.6.3"
-    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_cuda
+    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_cuda-12.6.3
+  test_cuda-12-8-1:
+    build:
+      context: .
+      dockerfile: test_cuda.Dockerfile
+      args:
+        <<: *common_args
+        CUDA_VERSION: "12.8.1"
+    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_cuda-12.8.1

--- a/tests/test-cuda.bsh
+++ b/tests/test-cuda.bsh
@@ -9,15 +9,34 @@ source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
 
 : ${DOCKER=docker}
 
-if ! command -v "${DOCKER}" &> /dev/null; then
-  skip_next_test
-fi
-begin_test "CUDA"
-(
-  setup_test
-
-  RESULT="$("${DOCKER}" run --rm vsiri/test_recipe:test_cuda bash -c '/usr/local/cuda/bin/nvcc --version')"
-  assert_sub_str "${RESULT}" "Cuda compilation tools, release 12.6"
-
+# test CUDA with different versions
+CUDA_TEST_ID_ARRAY=(
+    "12.6.3"
+    "12.8.1"
 )
-end_test
+CUDA_EXPECTED_ARRAY=(
+    "Cuda compilation tools, release 12.6"
+    "Cuda compilation tools, release 12.8"
+)
+
+for i in "${!CUDA_TEST_ID_ARRAY[@]}"; do
+
+  # test options
+  CUDA_TEST_ID="${CUDA_TEST_ID_ARRAY[$i]}"
+  CUDA_EXPECTED="${CUDA_EXPECTED_ARRAY[$i]}"
+
+  # run test
+  if ! command -v "${DOCKER}" &> /dev/null; then
+    skip_next_test
+  fi
+  begin_test "CUDA ${CUDA_TEST_ID}"
+  (
+    setup_test
+
+    RESULT="$("${DOCKER}" run --rm "vsiri/test_recipe:test_cuda-${CUDA_TEST_ID}" bash -c '/usr/local/cuda/bin/nvcc --version')"
+    assert_sub_str "${RESULT}" "${CUDA_EXPECTED}"
+
+  )
+  end_test
+
+done


### PR DESCRIPTION
CUDA Dockerfile format changed from `ENV VAR VAL` [link](https://gitlab.com/nvidia/container-images/cuda/-/blob/d431a81b4e0dc7d43f2a66880edd16424550ca31/dist/12.8.1/ubi8/base/Dockerfile) to `ENV VAR=VAL` [link](https://gitlab.com/nvidia/container-images/cuda/-/blob/d431a81b4e0dc7d43f2a66880edd16424550ca31/dist/12.6.3/ubi8/base/Dockerfile), requiring a parsing change to handle both options.

Tests for CUDA 12.6.3 and 12.8.1 to confirm expected operation for both `ENV` formats.

