### PR TITLE
Skip GPG

### DIFF
--- a/recipe_gosu.Dockerfile
+++ b/recipe_gosu.Dockerfile
@@ -15,9 +15,12 @@ ONBUILD RUN apk add --no-cache --virtual .deps curl dpkg gnupg openssl; \
                 export GNUPGHOME=/dev/shm; \
                 for server in $(shuf -e ha.pool.sks-keyservers.net \
                                         hkp://p80.pool.sks-keyservers.net:80 \
+                                        keys.openpgp.org \
+                                        hkp://keys.openpgp.org:80 \
                                         keyserver.ubuntu.com \
                                         hkp://keyserver.ubuntu.com:80 \
-                                        pgp.mit.edu ); do \
+                                        pgp.mit.edu \
+                                        hkp://pgp.mit.edu:80 ); do \
                     gpg --batch --keyserver "${server}" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || :; \
                 done; \
                 gpg --batch --verify /dev/shm/gosu.asc /usr/local/bin/gosu; \

--- a/recipe_gosu.Dockerfile
+++ b/recipe_gosu.Dockerfile
@@ -3,22 +3,25 @@ FROM alpine:3.11.8
 SHELL ["/usr/bin/env", "sh", "-euxvc"]
 
 ONBUILD ARG GOSU_VERSION=1.11
+ONBUILD ARG GOSU_SKIP_GPG=0
 ONBUILD RUN apk add --no-cache --virtual .deps curl dpkg gnupg openssl; \
             # download gosu
             dpkgArch="$(dpkg --print-architecture | awk -F- '{print $NF}')"; \
             curl -fsSRLo /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}"; \
             chmod +x /usr/local/bin/gosu; \
             # verify the signature
-            curl -fsSLo /dev/shm/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"; \
-            export GNUPGHOME=/dev/shm; \
-            for server in $(shuf -e ha.pool.sks-keyservers.net \
-                                    hkp://p80.pool.sks-keyservers.net:80 \
-                                    keyserver.ubuntu.com \
-                                    hkp://keyserver.ubuntu.com:80 \
-                                    pgp.mit.edu); do \
-                gpg --batch --keyserver "${server}" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || :; \
-            done; \
-            gpg --batch --verify /dev/shm/gosu.asc /usr/local/bin/gosu; \
+            if [ "${GOSU_SKIP_GPG}" != "1" ]; then \
+                curl -fsSLo /dev/shm/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"; \
+                export GNUPGHOME=/dev/shm; \
+                for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                        hkp://p80.pool.sks-keyservers.net:80 \
+                                        keyserver.ubuntu.com \
+                                        hkp://keyserver.ubuntu.com:80 \
+                                        pgp.mit.edu ); do \
+                    gpg --batch --keyserver "${server}" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || :; \
+                done; \
+                gpg --batch --verify /dev/shm/gosu.asc /usr/local/bin/gosu; \
+            fi; \
             # verify that the binary works
             gosu nobody true; \
             # cleanup

--- a/recipe_tini-musl.Dockerfile
+++ b/recipe_tini-musl.Dockerfile
@@ -5,20 +5,23 @@ SHELL ["/usr/bin/env", "sh", "-euxvc"]
 ADD tini /usr/local/bin/tini
 
 ONBUILD ARG TINI_VERSION=v0.18.0
+ONBUILD ARG TINI_SKIP_GPG=0
 ONBUILD RUN apk add --no-cache --virtual .deps gnupg curl ca-certificates; \
             # download tini
             curl -fsSRLo /usr/local/bin/_tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-muslc-amd64; \
             chmod +x /usr/local/bin/tini /usr/local/bin/_tini; \
             # verify the signature
-            curl -fsSLo /dev/shm/tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-muslc-amd64.asc; \
-            export GNUPGHOME=/dev/shm; \
-            for server in $(shuf -e ha.pool.sks-keyservers.net \
-                                    hkp://p80.pool.sks-keyservers.net:80 \
-                                    keyserver.ubuntu.com \
-                                    hkp://keyserver.ubuntu.com:80 \
-                                    pgp.mit.edu) ; do \
-                gpg --batch --keyserver "${server}" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
-            done; \
-            gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/_tini; \
+            if [ "${TINI_SKIP_GPG-}" != "1" ]; then \
+                curl -fsSLo /dev/shm/tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-muslc-amd64.asc; \
+                export GNUPGHOME=/dev/shm; \
+                for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                        hkp://p80.pool.sks-keyservers.net:80 \
+                                        keyserver.ubuntu.com \
+                                        hkp://keyserver.ubuntu.com:80 \
+                                        pgp.mit.edu ); do \
+                    gpg --batch --keyserver "${server}" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
+                done; \
+                gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/_tini; \
+            fi; \
             # cleanup to keep intermediate image samell
             apk del .deps

--- a/recipe_tini-musl.Dockerfile
+++ b/recipe_tini-musl.Dockerfile
@@ -16,9 +16,12 @@ ONBUILD RUN apk add --no-cache --virtual .deps gnupg curl ca-certificates; \
                 export GNUPGHOME=/dev/shm; \
                 for server in $(shuf -e ha.pool.sks-keyservers.net \
                                         hkp://p80.pool.sks-keyservers.net:80 \
+                                        keys.openpgp.org \
+                                        hkp://keys.openpgp.org:80 \
                                         keyserver.ubuntu.com \
                                         hkp://keyserver.ubuntu.com:80 \
-                                        pgp.mit.edu ); do \
+                                        pgp.mit.edu \
+                                        hkp://pgp.mit.edu:80 ); do \
                     gpg --batch --keyserver "${server}" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
                 done; \
                 gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/_tini; \

--- a/recipe_tini.Dockerfile
+++ b/recipe_tini.Dockerfile
@@ -5,20 +5,23 @@ SHELL ["/usr/bin/env", "sh", "-euxvc"]
 ADD tini /usr/local/bin/tini
 
 ONBUILD ARG TINI_VERSION=v0.18.0
+ONBUILD ARG TINI_SKIP_GPG=0
 ONBUILD RUN apk add --no-cache --virtual .deps gnupg curl ca-certificates; \
             # download tini
             curl -fsSRLo /usr/local/bin/_tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini; \
             chmod +x /usr/local/bin/_tini /usr/local/bin/tini; \
             # verify the signature
-            curl -fsSLo /dev/shm/tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc; \
-            export GNUPGHOME=/dev/shm; \
-            for server in $(shuf -e ha.pool.sks-keyservers.net \
-                                    hkp://p80.pool.sks-keyservers.net:80 \
-                                    keyserver.ubuntu.com \
-                                    hkp://keyserver.ubuntu.com:80 \
-                                    pgp.mit.edu) ; do \
-                gpg --batch --keyserver "${server}" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
-            done; \
-            gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/_tini; \
+            if [ "${TINI_SKIP_GPG-}" != "1" ]; then \
+                curl -fsSLo /dev/shm/tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc; \
+                export GNUPGHOME=/dev/shm; \
+                for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                        hkp://p80.pool.sks-keyservers.net:80 \
+                                        keyserver.ubuntu.com \
+                                        hkp://keyserver.ubuntu.com:80 \
+                                        pgp.mit.edu ); do \
+                    gpg --batch --keyserver "${server}" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
+                done; \
+                gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/_tini; \
+            fi; \
             # cleanup to keep intermediate image samell
             apk del .deps

--- a/recipe_tini.Dockerfile
+++ b/recipe_tini.Dockerfile
@@ -16,9 +16,12 @@ ONBUILD RUN apk add --no-cache --virtual .deps gnupg curl ca-certificates; \
                 export GNUPGHOME=/dev/shm; \
                 for server in $(shuf -e ha.pool.sks-keyservers.net \
                                         hkp://p80.pool.sks-keyservers.net:80 \
+                                        keys.openpgp.org \
+                                        hkp://keys.openpgp.org:80 \
                                         keyserver.ubuntu.com \
                                         hkp://keyserver.ubuntu.com:80 \
-                                        pgp.mit.edu ); do \
+                                        pgp.mit.edu \
+                                        hkp://pgp.mit.edu:80 ); do \
                     gpg --batch --keyserver "${server}" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
                 done; \
                 gpg --batch --verify /dev/shm/tini.asc /usr/local/bin/_tini; \


### PR DESCRIPTION
For the gosu and tini recipes:

1. Allow users to skip GPG checks via build arguments `GOSU_SKIP_GPG=1` and/or `TINI_SKIP_GPG=1`.  Skipping is useful if key servers are down or otherwise inaccessible.
1. More gpg servers - specifically
    - `keys.openpgp.org`
    -  `hkp://keys.openpgp.org:80`
    - `hkp://pgp.mit.edu:80`