### PR TITLE
pipenv fake_package __init__.py

### DIFF
--- a/30_get-pipenv
+++ b/30_get-pipenv
@@ -275,7 +275,7 @@ set -eu
 # $2 - subdir
 
 mkdir -p "${2-${1}}"
-touch "${2-${1}}/init.py"
+touch "${2-${1}}/__init__.py"
 if [ ! -e "setup.py" ]; then
   echo "from distutils.core import setup" > setup.py
   echo "setup(name='${1}', packages=['${2-${1}}'], description='Project')" >> setup.py

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       dockerfile: test_pipenv.Dockerfile
       args:
         <<: *common_args
-        PIPENV_VERSION: "2021.11.23"
-        VIRTUALENV_VERSION: "20.13.3"
+        PIPENV_VERSION: "2026.0.3"
+        VIRTUALENV_VERSION: "20.36.1"
         PIPENV_VIRTUALENV: "/foo"
         PIPENV_PYTHON: "/bar"
     image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_pipenv

--- a/tests/test-pipenv.bsh
+++ b/tests/test-pipenv.bsh
@@ -17,7 +17,10 @@ begin_test "Pipenv"
   setup_test
 
   RESULT="$(docker run --rm vsiri/test_recipe:test_pipenv bash -c 'head -n1 /foo/bin/pipenv; readlink /foo/bin/python; /foo/bin/pipenv --version')"
-  [ "${RESULT}" = $'#!/foo/bin/python\n/bar\npipenv, version 2021.11.23' ]
+  [ "${RESULT}" = $'#!/foo/bin/python\n/bar\npipenv, version 2026.0.3' ]
+
+  RESULT="$(docker run --rm vsiri/test_recipe:test_pipenv bash -c '/foo/bin/pipenv run python3 -c "import abcd; print(abcd.__path__)"')"
+  [ "${RESULT}" = "['/src/packages/abcd/abcd']" ]
 
 )
 end_test

--- a/tests/test_pipenv.Dockerfile
+++ b/tests/test_pipenv.Dockerfile
@@ -2,9 +2,16 @@ ARG VSI_RECIPE_REPO=vsiri/recipe
 
 FROM ${VSI_RECIPE_REPO}:pipenv AS pipenv
 
-FROM python:3.8
+FROM python:3.10
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
 COPY --from=pipenv /usr/local /usr/local
 RUN ln -s "$(which python3)" /bar; \
     shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
+
+ENV PIPENV_PIPFILE=/src/Pipfile
+
+RUN mkdir -p /src/packages/abcd; \
+    (cd /src/packages/abcd; "/foo/bin/fake_package" abcd); \
+    echo -e '[packages]\nabcd = {editable = true, path = "./packages/abcd"}' >> /src/Pipfile; \
+    "/foo/bin/pipenv" install;


### PR DESCRIPTION
For the pipenv recipe, when the `fake_package` function uses `init.py` rather than `__init__.py`, newer pip will instantiate the included package as a namespace package `_NamespacePath`.  At runtime, even if the real package includes `__Init__.py`, that file will not be loaded leading to various issues.

Update `fake_package` to use `__init__.py`.

Update the pipenv docker unit test with newer python/pipenv, and ensure an installed `<package>.__path__` is not a `_NamespacePath`.