### PR TITLE
BUG: conda-python recipe missing pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -488,14 +488,17 @@ Conda's python
 ============ ============
 Name         Python
 Build Args   ``USE_MINICONDA`` - Set to ``1`` to use miniconda instead of miniforge
+Build Args   ``PIP_VERSION`` - Version of pip to download
 Build Args   ``PYTHON_VERSION`` - Version of python to download
 Build Args   ``PYTHON_INSTALL_DIR`` - Location where python will be installed. While you can copy this directory to another docker image, care should be taken as to not change the final absolute path, as python will not be happy about that (e.g. tk/tcl paths will be broken).
 Output dir   ``/usr/local``
 ============ ============
 
-This is not a recipe for installing anaconda or miniforge, rather it internally uses miniforge to install a "not" conda python environment. This python will still bare the markings of Anaconda, but does not have all the conda modifications, and works as a normal and extremely portable version of python for glibc linux.
+This is not a recipe for installing anaconda or miniforge, rather it internally uses miniforge to install a "not" conda python environment. This python will still bear the markings of Anaconda, but does not have all the conda modifications, and works as a normal and extremely portable version of python for glibc linux.
 
-See https://anaconda.org/conda-forge/python/files (for miniforge)/ https://anaconda.org/anaconda/python/files (for miniconda) for values of ``PYTHON_VERSION``
+See https://anaconda.org/conda-forge/python/files (for miniforge)/ https://anaconda.org/anaconda/python/files (for miniconda) for values of ``PYTHON_VERSION``.
+
+See https://anaconda.org/conda-forge/pip/files (for miniforge)/ https://anaconda.org/anaconda/pip/files (for miniconda) for values of ``PIP_VERSION``.
 
 This is the easiest way to install an arbitrary version of python on an arbitrary linux distro.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
       context: .
       dockerfile: recipe_conda_python.Dockerfile
       # args:
+      #   PIP_VERSION: "${PIP_VERSION}"
       #   PYTHON_VERSION: "${PYTHON_VERSION}"
       #   PYTHON_INSTALL_DIR: "${PYTHON_INSTALL_DIR}"
       #   USE_MINICONDA: ${USE_MINICONDA}"

--- a/recipe_conda_python.Dockerfile
+++ b/recipe_conda_python.Dockerfile
@@ -18,4 +18,5 @@ ONBUILD RUN if [ "${USE_MINICONDA}" = "1" ]; then \
 
 ONBUILD ARG PYTHON_VERSION=3.8.5
 ONBUILD ARG PYTHON_INSTALL_DIR=/usr/local
-ONBUILD RUN /conda/bin/conda create -y -p "${PYTHON_INSTALL_DIR}" "python==${PYTHON_VERSION}"
+ONBUILD ARG PIP_VERSION=
+ONBUILD RUN /conda/bin/conda create -y -p "${PYTHON_INSTALL_DIR}" "python==${PYTHON_VERSION}" "pip${PIP_VERSION:+==${PIP_VERSION}}"


### PR DESCRIPTION
`conda` made changes so that `pip` is no longer installed by default. Adds that functionality back in, with an optional variable to set the version.