### PR TITLE
uv recipe

### DIFF
--- a/30_get-uv
+++ b/30_get-uv
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+set -eu
+
+# variables
+: ${UV_INSTALL_SH="/usr/local/share/just/temp/uv_install.sh"}
+: ${UV_INSTALL_DIR="/usr/local/bin"}
+
+# pre-downloaded install script
+if [ ! -f "${UV_INSTALL_SH}" ]; then
+  echo "Missing UV install script" >&2
+  exit 1
+fi
+
+# call install script
+UV_INSTALL_DIR="${UV_INSTALL_DIR}" sh "${UV_INSTALL_SH}"
+
+# delete files after install
+# This script is so simple, there's no reason to support sourcing this file
+if [ -n "${BASH_SOURCE+set}" ]; then
+  if [[ ${BASH_SOURCE[0]} = *30_get-uv ]]; then # CYA
+    exec sh -c "rm '${BASH_SOURCE[0]}' '${UV_INSTALL_SH}'"
+  fi
+else
+  case "${0}" in
+    *30_get-uv) # CYA
+      exec sh -c "rm '${0}' '${UV_INSTALL_SH}'"
+      ;;
+  esac
+fi

--- a/README.rst
+++ b/README.rst
@@ -537,6 +537,32 @@ Users may alternatively make use of `remotely hosted PROJ-data <https://proj.org
    COPY --from=proj-data /usr/local /usr/local
 
 
+uv
+---
+
+=========== ======
+Name        uv
+Env Var     ``UV_VERSION`` - Optional version of uv to install
+Output dir  ``/usr/local``
+=========== ======
+
+An extremely fast Python package and project manager, written in Rust.
+
+A script called ``/usr/local/bin/pip-fake`` is also added, useful for creating fake editable packages that will be mounted in at run time.
+
+.. rubric:: Example
+
+.. code-block:: Dockerfile
+
+   FROM vsiri/recipe:uv as uv
+   FROM redhat:ubi9
+
+   COPY --from=uv /usr/local /usr/local
+   ...
+   # Only needs to be run once for all recipes
+   RUN shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
+
+
 J.U.S.T.
 ========
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,3 +147,11 @@ services:
       #   LIBGLVND_VERSION: "${LIBGLVND_VERSION}"
       #   CUDA_RECIPE_TARGET: "${CUDA_RECIPE_TARGET}"
     image: ${VSI_RECIPE_REPO-vsiri/recipe}:cudagl
+
+  uv:
+    build:
+      context: .
+      dockerfile: recipe_uv.Dockerfile
+      # args:
+      #   UV_VERSION: "${UV_VERSION}"
+    image: ${VSI_RECIPE_REPO-vsiri/recipe}:uv

--- a/recipe_uv.Dockerfile
+++ b/recipe_uv.Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.11.8
+
+SHELL ["/usr/bin/env", "sh", "-euxvc"]
+
+COPY --chmod=755 30_get-uv /usr/local/share/just/container_build_patch/
+COPY --chmod=755 pip-fake /usr/local/bin/
+
+ONBUILD ARG UV_VERSION
+ONBUILD ARG RECIPE_UV_VERSION="${UV_VERSION}"
+
+ONBUILD RUN apk add --no-cache --virtual .deps curl ca-certificates; \
+            URL="https://astral.sh/uv/${RECIPE_UV_VERSION}/install.sh"; \
+            FILE="/usr/local/share/just/temp/uv_install.sh"; \
+            mkdir -p "$(dirname "${FILE}")"; \
+            curl -fsSRL "${URL}" -o "${FILE}";

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -62,3 +62,11 @@ services:
         <<: *common_args
         CUDA_VERSION: "12.8.1"
     image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_cuda-12.8.1
+  test_uv:
+    build:
+      context: .
+      dockerfile: test_uv.Dockerfile
+      args:
+        <<: *common_args
+        RECIPE_UV_VERSION: "0.11.18"
+    image: ${VSI_TEST_RECIPE_REPO-vsiri/test_recipe}:test_uv

--- a/tests/test-uv.bsh
+++ b/tests/test-uv.bsh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+if [ -z "${VSI_COMMON_DIR+set}" ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.."; pwd)"
+fi
+
+source "${VSI_COMMON_DIR}/tests/testlib.bsh"
+source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
+
+: ${DOCKER=docker}
+
+# test uv in docker
+if ! command -v "${DOCKER}" &> /dev/null; then
+  skip_next_test
+fi
+begin_test "uv"
+(
+  setup_test
+
+  RESULT="$(docker run --rm vsiri/test_recipe:test_uv bash -c 'cd /foo; uv run python --version; uv pip freeze')"
+  assert_sub_str "${RESULT}" "Python 3.13.12"
+  assert_sub_str "${RESULT}" "numpy==2.4.5"
+)
+end_test

--- a/tests/test_uv.Dockerfile
+++ b/tests/test_uv.Dockerfile
@@ -1,0 +1,12 @@
+ARG VSI_RECIPE_REPO=vsiri/recipe
+
+FROM ${VSI_RECIPE_REPO}:uv AS uv
+
+FROM redhat/ubi9
+SHELL ["/usr/bin/env", "bash", "-euxvc"]
+
+COPY --from=uv /usr/local /usr/local
+RUN for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done;
+
+RUN mkdir -p /foo; cd /foo; \
+    uv init --python 3.13.12; uv add "numpy==2.4.5"


### PR DESCRIPTION
New recipe for `uv`.  This recipe builds on the installer that `uv` already provides, downloading the (optionally versioned) installer to `/usr/local/share/just/temp/uv_install.sh` using ONBUILD, then running the installer in the downstream container via the standard `container_build_patch` workflow.